### PR TITLE
get go packages with a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,7 @@ $ transfer test.txt
 npm install
 bower install
 
-go get github.com/PuerkitoBio/ghost/handlers
-go get github.com/gorilla/mux
-go get github.com/dutchcoders/go-clamd
-go get github.com/goamz/goamz/s3
-go get github.com/goamz/goamz/aws
-go get github.com/golang/gddo/httputil/header
-go get github.com/kennygrant/sanitize
+cd transfersh-web && go get ./
 
 grunt serve
 grunt build

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ transfer test.txt
 npm install
 bower install
 
-cd transfersh-web && go get ./
+cd transfersh-server && go get ./
 
 grunt serve
 grunt build


### PR DESCRIPTION
Hi,

I just noticed that your README instructs people to get each go dependency with separate command. However, implying that the repository is cloned via git, you can get all go dependencies with simply running `go get ./`. on the go application root.

I fiddled with the README already, but did not find a good way to install the dependencies without leaving the application root. Running `go get ./transfersh-server` does not work and using the current patch I made leaves you in the ./transfersh-server folder. Should you have an opinion how to deal with this, I'll tidy my commit as so.
