### PR TITLE
fixed example of downloading file command

### DIFF
--- a/transfersh-web/index.html
+++ b/transfersh-web/index.html
@@ -131,10 +131,10 @@ include "includes/head.html"
                         <code>
                             <span class="code-title"># Uploading is easy using curl</span>
                             <br>$ curl --upload-file ./hello.txt https://transfer.sh/hello.txt
-                            <br>
+                            <br>https://transfer.sh/66nb8/hello.txt
                             <br>
                             <span class="code-title"># Download the file</span>
-                            <br>$ curl https://transfer.sh/hello.txt -o hello.txt
+                            <br>$ curl https://transfer.sh/66nb8/hello.txt -o hello.txt
                         </code>
                     </div>
                 </div>


### PR DESCRIPTION
Fixed the example of downloading file using curl and removed some spaces.

Changed `curl --upload-file ./hello.txt https://transfer.sh/hello.txt`
To `curl https://transfer.sh/hello.txt -o hello.txt`
