### PR TITLE
s3: Move from goamz to minio-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ Contributions are welcome.
 
 Code and documentation copyright 2011-2014 Remco Verhoef. 
 Code released under [the MIT license](LICENSE). 
+

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -216,13 +216,15 @@ func New() *Cmd {
 
 		switch provider := c.String("provider"); provider {
 		case "s3":
-			if accessKey := c.String("aws-access-key"); accessKey == "" {
+			if endpoint := c.String("s3-endpoint"); endpoint == "" {
+				endpoint = "s3.amazonaws.com"
+			} else if accessKey := c.String("aws-access-key"); accessKey == "" {
 				panic("access-key not set.")
 			} else if secretKey := c.String("aws-secret-key"); secretKey == "" {
 				panic("secret-key not set.")
 			} else if bucket := c.String("bucket"); bucket == "" {
 				panic("bucket not set.")
-			} else if storage, err := server.NewS3Storage(accessKey, secretKey, bucket); err != nil {
+			} else if storage, err := server.NewS3Storage(endpoint, accessKey, secretKey, bucket); err != nil {
 				panic(err)
 			} else {
 				options = append(options, server.UseStorage(storage))

--- a/server/utils.go
+++ b/server/utils.go
@@ -30,55 +30,11 @@ import (
 	"net/mail"
 	"strconv"
 	"strings"
-	"time"
 
-	"github.com/goamz/goamz/aws"
-	"github.com/goamz/goamz/s3"
 	"github.com/golang/gddo/httputil/header"
 )
 
-func getBucket(accessKey, secretKey, bucket string) (*s3.Bucket, error) {
-	auth, err := aws.GetAuth(accessKey, secretKey, "", time.Time{})
-	if err != nil {
-		return nil, err
-	}
-
-	var EUWestWithoutHTTPS = aws.Region{
-		Name:                 "eu-west-1",
-		EC2Endpoint:          "https://ec2.eu-west-1.amazonaws.com",
-		S3Endpoint:           "http://s3-eu-west-1.amazonaws.com",
-		S3BucketEndpoint:     "",
-		S3LocationConstraint: true,
-		S3LowercaseBucket:    true,
-		SDBEndpoint:          "https://sdb.eu-west-1.amazonaws.com",
-		SESEndpoint:          "https://email.eu-west-1.amazonaws.com",
-		SNSEndpoint:          "https://sns.eu-west-1.amazonaws.com",
-		SQSEndpoint:          "https://sqs.eu-west-1.amazonaws.com",
-		IAMEndpoint:          "https://iam.amazonaws.com",
-		ELBEndpoint:          "https://elasticloadbalancing.eu-west-1.amazonaws.com",
-		DynamoDBEndpoint:     "https://dynamodb.eu-west-1.amazonaws.com",
-		CloudWatchServicepoint: aws.ServiceInfo{
-			Endpoint: "https://monitoring.eu-west-1.amazonaws.com",
-			Signer:   aws.V2Signature,
-		},
-		AutoScalingEndpoint: "https://autoscaling.eu-west-1.amazonaws.com",
-		RDSEndpoint: aws.ServiceInfo{
-			Endpoint: "https://rds.eu-west-1.amazonaws.com",
-			Signer:   aws.V2Signature,
-		},
-		STSEndpoint:             "https://sts.amazonaws.com",
-		CloudFormationEndpoint:  "https://cloudformation.eu-west-1.amazonaws.com",
-		ECSEndpoint:             "https://ecs.eu-west-1.amazonaws.com",
-		DynamoDBStreamsEndpoint: "https://streams.dynamodb.eu-west-1.amazonaws.com",
-	}
-
-	conn := s3.New(auth, EUWestWithoutHTTPS)
-	b := conn.Bucket(bucket)
-	return b, nil
-}
-
 func formatNumber(format string, s uint64) string {
-
 	return RenderFloat(format, float64(s))
 }
 


### PR DESCRIPTION
goamz is not maintained anymore move to maintained
library like `minio-go`.

`minio-go` supports S3 and many other s3 compatible
vendors. `minio-go` also supports both Signature V2 and
Signature V4. This in-turn would enable `transfer.sh`
to be able to use many different S3 compatible storage
vendors.

Fixes #5
