### PR TITLE
Fix mixed content on front page

### DIFF
--- a/transfersh-server/static/index.html
+++ b/transfersh-server/static/index.html
@@ -328,8 +328,8 @@
             <br>
             <br>
 
-            <iframe src="https://mdo.github.io/github-buttons/github-btn.html?user=dutchcoders&repo=transfer.sh&type=follow&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="250" height="50"></iframe>
-            <iframe src="https://mdo.github.io/github-buttons/github-btn.html?user=dutchcoders&repo=transfer.sh&type=watch&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="200" height="50"></iframe>
+            <iframe src="https://ghbtns.com/github-btn.html?user=dutchcoders&repo=transfer.sh&type=follow&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="250" height="50"></iframe>
+            <iframe src="https://ghbtns.com/github-btn.html?user=dutchcoders&repo=transfer.sh&type=watch&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="200" height="50"></iframe>
         </div>
     </section>
     <section id="reviews">

--- a/transfersh-web/index.html
+++ b/transfersh-web/index.html
@@ -302,8 +302,8 @@ include "includes/head.html"
             <br>
             <br>
 
-            <iframe src="https://mdo.github.io/github-buttons/github-btn.html?user=dutchcoders&repo=transfer.sh&type=follow&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="250" height="50"></iframe>
-            <iframe src="https://mdo.github.io/github-buttons/github-btn.html?user=dutchcoders&repo=transfer.sh&type=watch&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="200" height="50"></iframe>
+            <iframe src="https://ghbtns.com/github-btn.html?user=dutchcoders&repo=transfer.sh&type=follow&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="250" height="50"></iframe>
+            <iframe src="https://ghbtns.com/github-btn.html?user=dutchcoders&repo=transfer.sh&type=watch&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="200" height="50"></iframe>
         </div>
     </section>
     <section id="reviews">


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed mixed content on the front page introduced by a redirect on the old generator page for Github embeds

Now it links directly to [Github buttons](https://ghbtns.com/) and goes over HTTPS.
