### PR TITLE
Switch to alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.7-alpine
 MAINTAINER Remco Verhoef <remco@dutchcoders.io>
 
 # Copy the local package files to the container's workspace.


### PR DESCRIPTION
This drastically decreases the overall image size. Quick comparison:

```
# Image fetched from Docker Hub
dutchcoders/transfer.sh   latest              a875ed5dfa56        5 months ago        704MB
# Image just built
dutchcoders/transfer.sh   latest              a220c49297eb        4 minutes ago       269MB
```