### PR TITLE
multi-stages Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,25 @@
-FROM golang:1.7-alpine
+FROM golang as builder
 MAINTAINER Remco Verhoef <remco@dutchcoders.io>
 
 # Copy the local package files to the container's workspace.
 ADD . /go/src/github.com/dutchcoders/transfer.sh
+WORKDIR /go/src/github.com/dutchcoders/transfer.sh
 
-# build & install server
-RUN go build -o /go/bin/transfersh github.com/dutchcoders/transfer.sh
+# build binarie
+RUN set -x && \
+    go get -d -v . && \
+    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o transfersh .
 
-ENTRYPOINT ["/go/bin/transfersh", "--listener", ":8080", "--provider", "s3"]  
+# Take an empty container
+FROM scratch
+
+WORKDIR /root/
+
+# Copy the binarie
+RUN set -x && \
+COPY --from=builder /go/src/github.com/dutchcoders/transfer.sh/transfersh .
 
 EXPOSE 8080 8080
+
+# Entrypoint to launch properly the container
+ENTRYPOINT ["/root/transfersh"]


### PR DESCRIPTION
Hi,

With these changes, the Docker images move from 269MB to 12.4MB. 

It start FROM a Golang image, and then put the go server in a SCRATCH image.