### PR TITLE
Add "Windows support" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ alias transfer=transfer
 $ transfer test.txt
 ```
 
+### On Windows
+
+Download [curl](https://curl.haxx.se/download.html). Then, put a file called transfer.cmd somewhere in your PATH with this inside it:
+```
+@echo off
+setlocal
+:: write to output to tmpfile because of progress bar
+set tmpfile=%TEMP%\~%~nx1.transfer
+curl --progress-bar --upload-file %1 https://transfer.sh/%~nx1 >> %tmpfile%
+type %tmpfile%
+del %tmpfile%
+```
+
 ## Usage
 
 Parameter | Description | Value | Env

--- a/README.md
+++ b/README.md
@@ -40,11 +40,10 @@ Download [curl](https://curl.haxx.se/download.html). Then, put a file called tra
 ```
 @echo off
 setlocal
-:: write to output to tmpfile because of progress bar
-set tmpfile=%TEMP%\~%~nx1.transfer
-curl --progress-bar --upload-file %1 https://transfer.sh/%~nx1 >> %tmpfile%
-type %tmpfile%
-del %tmpfile%
+:: use env vars to pass names to PS, to avoid escaping issues
+set FN=%~nx1
+set FULL=%1
+powershell -noprofile -command "$(Invoke-Webrequest -Method put -Infile $Env:FULL https://transfer.sh/$Env:FN).Content"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ transfer test.txt
 
 ### On Windows
 
-Download [curl](https://curl.haxx.se/download.html). Then, put a file called transfer.cmd somewhere in your PATH with this inside it:
+Put a file called transfer.cmd somewhere in your PATH with this inside it:
 ```
 @echo off
 setlocal


### PR DESCRIPTION
Added a section that explains how to get the `transfer` alias on Windows.