### PR TITLE
Add: Support for Authenticated Uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ listener | port to use for http (:80) | |
 profile-listener | port to use for profiler (:6060)| |
 force-https | redirect to https | false |
 tls-listener | port to use for https (:443) | |
-tls-cert-file | path to tls certificate | | 
+tls-cert-file | path to tls certificate | |
 tls-private-key | path to tls private key | |
 temp-path | path to temp folder | system temp |
 web-path | path to static web files (for development) | |
@@ -50,9 +50,10 @@ provider | which storage provider to use | (s3 or local) |
 aws-access-key | aws access key | | AWS_ACCESS_KEY
 aws-secret-key | aws access key | | AWS_SECRET_KEY
 bucket | aws bucket | | BUCKET
-basedir | path storage for local provider| | 
-lets-encrypt-hosts | hosts to use for lets encrypt certificates (comma seperated) | | 
-log | path to log file| | 
+basedir | path storage for local provider| |
+auth-key | key to use for authentication (must be supplied in 'Authorization' header with each request)| |
+lets-encrypt-hosts | hosts to use for lets encrypt certificates (comma seperated) | |
+log | path to log file| |
 
 If you want to use TLS using lets encrypt certificates, set lets-encrypt-hosts to your domain, set tls-listener to :443 and enable force-https.
 
@@ -63,7 +64,7 @@ If you want to use TLS using your own certificates, set tls-listener to :443, fo
 Make sure your GOPATH is set correctly.
 
 ```
-go run main.go -provider=local --listener :8080 --temp-path=/tmp/ --basedir=/tmp/ 
+go run main.go -provider=local --listener :8080 --temp-path=/tmp/ --basedir=/tmp/
 ```
 
 ## Build
@@ -84,7 +85,7 @@ docker run --publish 8080:8080 dutchcoders/transfer.sh:latest --provider local -
 
 Contributions are welcome.
 
-## Creators 
+## Creators
 
 **Remco Verhoef**
 - <https://twitter.com/remco_verhoef>
@@ -94,5 +95,5 @@ Contributions are welcome.
 
 ## Copyright and license
 
-Code and documentation copyright 2011-2014 Remco Verhoef. 
-Code released under [the MIT license](LICENSE). 
+Code and documentation copyright 2011-2014 Remco Verhoef.
+Code released under [the MIT license](LICENSE).

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -139,6 +139,12 @@ var globalFlags = []cli.Flag{
 		Name:  "profiler",
 		Usage: "enable profiling",
 	},
+	cli.StringFlag{
+		Name:   "auth-key",
+		Usage:  "auth-key",
+		Value:  "",
+		EnvVar: "AUTH_KEY",
+	},
 }
 
 type Cmd struct {
@@ -196,6 +202,10 @@ func New() *Cmd {
 
 		if v := c.String("virustotal-key"); v != "" {
 			options = append(options, server.VirustotalKey(v))
+		}
+
+		if v := c.String("auth-key"); v != "" {
+			options = append(options, server.AuthenticateUploads(v))
 		}
 
 		if v := c.String("clamav-host"); v != "" {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -760,3 +760,17 @@ func LoveHandler(h http.Handler) http.HandlerFunc {
 		h.ServeHTTP(w, r)
 	}
 }
+
+func (s *Server) AuthenticatedHandler (h http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		authKey := r.Header.Get ("Authorization")
+
+		if s.AuthKey != "" && authKey != s.AuthKey {
+			log.Printf("Recieved: Bad Auth Token: %s", authKey)
+			http.Error(w, errors.New("Bad Auth Token").Error(), 403)
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -75,6 +75,12 @@ func VirustotalKey(s string) OptionFn {
 	}
 }
 
+func AuthenticateUploads(key string) OptionFn {
+	return func(srvr *Server) {
+		srvr.AuthKey = key
+	}
+}
+
 func Listener(s string) OptionFn {
 	return func(srvr *Server) {
 		srvr.ListenerString = s
@@ -189,6 +195,7 @@ type Server struct {
 	locks map[string]*sync.Mutex
 
 	rateLimitRequests int
+	AuthKey string
 
 	storage Storage
 
@@ -317,10 +324,10 @@ func (s *Server) Run() {
 
 	r.HandleFunc("/{filename}/virustotal", s.virusTotalHandler).Methods("PUT")
 	r.HandleFunc("/{filename}/scan", s.scanHandler).Methods("PUT")
-	r.HandleFunc("/put/{filename}", s.putHandler).Methods("PUT")
-	r.HandleFunc("/upload/{filename}", s.putHandler).Methods("PUT")
-	r.HandleFunc("/{filename}", s.putHandler).Methods("PUT")
-	r.HandleFunc("/", s.postHandler).Methods("POST")
+	r.HandleFunc("/put/{filename}", s.AuthenticatedHandler (http.HandlerFunc (s.putHandler))).Methods("PUT")
+	r.HandleFunc("/upload/{filename}", s.AuthenticatedHandler (http.HandlerFunc (s.putHandler))).Methods("PUT")
+	r.HandleFunc("/{filename}", s.AuthenticatedHandler (http.HandlerFunc (s.putHandler))).Methods("PUT")
+	r.HandleFunc("/", s.AuthenticatedHandler (http.HandlerFunc (s.postHandler))).Methods("POST")
 	// r.HandleFunc("/{page}", viewHandler).Methods("GET")
 
 	r.NotFoundHandler = http.HandlerFunc(s.notFoundHandler)


### PR DESCRIPTION
My stab at implementing authenticated uploads, which is a must have for private deployment scenarios (say, I want to set up file uploads on my own domain, but don't want to open it to the general public). This should resolve #92.

Documented it in the `README` as well.

@dutchcoders, please let me know if you require any changes.