### PR TITLE
Fixed bug with newline character when uploading multiple files

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -281,7 +281,7 @@ func (s *Server) postHandler(w http.ResponseWriter, r *http.Request) {
 			}
 
 			relativeURL, _ := url.Parse(path.Join(token, filename))
-			fmt.Fprint(w, getURL(r).ResolveReference(relativeURL).String())
+			fmt.Fprint(w, getURL(r).ResolveReference(relativeURL).String() + "\n")
 		}
 	}
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -411,7 +411,7 @@ func (s *Server) putHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 
 	relativeURL, _ := url.Parse(path.Join(token, filename))
-	fmt.Fprint(w, getURL(r).ResolveReference(relativeURL).String())
+	fmt.Fprint(w, getURL(r).ResolveReference(relativeURL).String() + "\n")
 }
 
 func getURL(r *http.Request) *url.URL {


### PR DESCRIPTION
This PR fixes bug, when transfer.sh returned links without delimiter `\n` so I've got something like this `https://transfer.sh/1234/file1https://transfer.sh/1234/file2`.

Now it should return something like this:
```
https://transfer.sh/1234/file1(\n)
https://transfer.sh/1234/file2(\n)
```

This bug was created in a3fe3fea. I can't imagine how can this bug exists for more than 1 year :smile: 

Deploy this to production as soon as possible. I want to make app that relies on this :slightly_smiling_face: 

Thank you.