### PR TITLE
added domain scheme/host for proxied docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:1.7-alpine
-LABEL maintainer="Remco Verhoef <remco@dutchcoders.io>"
+LABEL maintainer="Thomas Schädler <thomas@lambda.li>"
 
 # Copy the local package files to the container's workspace.
-ADD . /go/src/github.com/dutchcoders/transfer.sh
+ADD . /go/src/github.com/gufertum/transfer.sh
 
 # build & install server
-RUN go build -o /go/bin/transfersh github.com/dutchcoders/transfer.sh
+RUN go build -o /go/bin/transfersh github.com/gufertum/transfer.sh
 
 ENTRYPOINT ["/go/bin/transfersh", "--listener", ":8080", "--provider", "s3"]  
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ gdrive-client-json-filepath | path to client json config for gdrive provider| |
 gdrive-local-config-path | path to local transfer.sh config cache for gdrive provider| |
 lets-encrypt-hosts | hosts to use for lets encrypt certificates (comma seperated) | |
 log | path to log file| | 
+domain-url-scheme | domain url scheme (http or https) when running behind a proxy| | 
+domain-url-host | domain url host (fqdn) when running behind a proxy| | 
 
 If you want to use TLS using lets encrypt certificates, set lets-encrypt-hosts to your domain, set tls-listener to :443 and enable force-https.
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -173,6 +173,16 @@ var globalFlags = []cli.Flag{
 		Usage: "pass for http basic auth",
 		Value: "",
 	},
+	cli.StringFlag{
+		Name:  "domain-url-scheme",
+		Usage: "domain url scheme (http or https) when running behind a proxy",
+		Value: "",
+	},
+	cli.StringFlag{
+		Name:  "domain-url-host",
+		Usage: "domain url host (fqdn) when running behind a proxy",
+		Value: "",
+	},
 }
 
 type Cmd struct {
@@ -306,6 +316,12 @@ func New() *Cmd {
 			}
 		default:
 			panic("Provider not set or invalid.")
+		}
+
+		if domainUrlScheme := c.String("domain-url-scheme"); domainUrlScheme == "" {
+		} else if domainUrlHost := c.String("domain-url-host"); domainUrlHost == "" {
+		} else {
+			options = append(options, server.DomainUrl(domainUrlScheme, domainUrlHost))
 		}
 
 		srvr, err := server.New(

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -7,8 +7,8 @@ import (
 
 	"strings"
 
-	"github.com/dutchcoders/transfer.sh/server"
 	"github.com/fatih/color"
+	"github.com/gufertum/transfer.sh/server"
 	"github.com/minio/cli"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/dutchcoders/transfer.sh/cmd"
+import "github.com/gufertum/transfer.sh/cmd"
 
 func main() {
 	app := cmd.New()

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -300,6 +300,11 @@ func (s *Server) postHandler(w http.ResponseWriter, r *http.Request) {
 			}
 
 			relativeURL, _ := url.Parse(path.Join(token, filename))
+			var mappedUrl = getURL(r)
+			if s.DomainUrlScheme != "" && s.DomainUrlHost != "" {
+ 				mappedUrl.Scheme = s.DomainUrlScheme
+ 				mappedUrl.Host = s.DomainUrlHost
+ 			}
 			fmt.Fprint(w, getURL(r).ResolveReference(relativeURL).String())
 		}
 	}
@@ -443,6 +448,10 @@ func (s *Server) putHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("X-Url-Delete", resolveUrl(r, deleteUrl, true))
 
+	if s.DomainUrlScheme != "" && s.DomainUrlHost != "" {
+		relativeURL.Scheme = s.DomainUrlScheme
+		relativeURL.Host = s.DomainUrlHost
+	}
 	fmt.Fprint(w, resolveUrl(r, relativeURL, false))
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -210,6 +210,13 @@ func HttpAuthCredentials(user string, pass string) OptionFn {
 	}
 }
 
+func DomainUrl(scheme string, host string) OptionFn {
+	return func(srvr *Server) {
+		srvr.DomainUrlScheme = scheme
+		srvr.DomainUrlHost = host
+	}
+}
+
 type Server struct {
 	AuthUser string
 	AuthPass string
@@ -244,6 +251,9 @@ type Server struct {
 	Certificate string
 
 	LetsEncryptCache string
+	
+	DomainUrlScheme string
+	DomainUrlHost string
 }
 
 func New(options ...OptionFn) (*Server, error) {


### PR DESCRIPTION
Hi,
i added two new parameters to overrule the URL shown after uploading a new file, so 
it also works (shows the correct URL) on a docker container which runs behind a proxy.
Otherwise the URL will be like 'localhost:8080/xyz/test.sh' instead of 'domain.com/xyz/test.sh'.

Let me know, what you think if it....

Regards, Thomas