### PR TITLE
Fix hostname when proxied

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,15 @@ gdrive-client-json-filepath | path to client json config for gdrive provider| |
 gdrive-local-config-path | path to local transfer.sh config cache for gdrive provider| |
 lets-encrypt-hosts | hosts to use for lets encrypt certificates (comma seperated) | |
 log | path to log file| | 
+domain-url-scheme | domain url scheme (http or https) when running behind a proxy| |
+domain-url-host | domain url host (fqdn) when running behind a proxy| |
+
 
 If you want to use TLS using lets encrypt certificates, set lets-encrypt-hosts to your domain, set tls-listener to :443 and enable force-https.
 
 If you want to use TLS using your own certificates, set tls-listener to :443, force-https, tls-cert=file and tls-private-key.
+
+If you are running the docker container behind a proxy (apache, ngnix), you have to set domain-url-scheme and domain-url-host to match your real domain name name. Otherwise the URL will show up as localhost:port instead of domain.ext.
 
 ## Development
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -173,6 +173,16 @@ var globalFlags = []cli.Flag{
 		Usage: "pass for http basic auth",
 		Value: "",
 	},
+	cli.StringFlag{
+		Name:  "domain-url-scheme",
+		Usage: "domain url scheme (http or https) when running behind a proxy",
+		Value: "",
+	},
+	cli.StringFlag{
+		Name:  "domain-url-host",
+		Usage: "domain url host (fqdn) when running behind a proxy",
+		Value: "",
+	},
 }
 
 type Cmd struct {
@@ -306,6 +316,12 @@ func New() *Cmd {
 			}
 		default:
 			panic("Provider not set or invalid.")
+		}
+
+		if domainUrlScheme := c.String("domain-url-scheme"); domainUrlScheme == "" {
+		} else if domainUrlHost := c.String("domain-url-host"); domainUrlHost == "" {
+		} else {
+			options = append(options, server.DomainUrl(domainUrlScheme, domainUrlHost))
 		}
 
 		srvr, err := server.New(

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -300,6 +300,11 @@ func (s *Server) postHandler(w http.ResponseWriter, r *http.Request) {
 			}
 
 			relativeURL, _ := url.Parse(path.Join(token, filename))
+			var mappedUrl = getURL(r)
+			if s.DomainUrlScheme != "" && s.DomainUrlHost != "" {
+ 				mappedUrl.Scheme = s.DomainUrlScheme
+ 				mappedUrl.Host = s.DomainUrlHost
+ 			}
 			fmt.Fprint(w, getURL(r).ResolveReference(relativeURL).String())
 		}
 	}
@@ -443,6 +448,10 @@ func (s *Server) putHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("X-Url-Delete", resolveUrl(r, deleteUrl, true))
 
+	if s.DomainUrlScheme != "" && s.DomainUrlHost != "" {
+		relativeURL.Scheme = s.DomainUrlScheme
+		relativeURL.Host = s.DomainUrlHost
+	}
 	fmt.Fprint(w, resolveUrl(r, relativeURL, false))
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -210,6 +210,13 @@ func HttpAuthCredentials(user string, pass string) OptionFn {
 	}
 }
 
+func DomainUrl(scheme string, host string) OptionFn {
+	return func(srvr *Server) {
+		srvr.DomainUrlScheme = scheme
+		srvr.DomainUrlHost = host
+	}
+}
+
 type Server struct {
 	AuthUser string
 	AuthPass string
@@ -244,6 +251,9 @@ type Server struct {
 	Certificate string
 
 	LetsEncryptCache string
+	
+	DomainUrlScheme string
+	DomainUrlHost string
 }
 
 func New(options ...OptionFn) (*Server, error) {


### PR DESCRIPTION
Ok, this time, only the intended changes are contained in the pull request.
The change allows to use the docker container behind a proxy, by setting the returned domain/url to the correct ("real") value instead of returning 'localhost' (which is correct 'inside') the docker container, but not when proxied to a real domain name.