### PR TITLE
Add newline between URLs for multi-upload

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -300,7 +300,7 @@ func (s *Server) postHandler(w http.ResponseWriter, r *http.Request) {
 			}
 
 			relativeURL, _ := url.Parse(path.Join(token, filename))
-			fmt.Fprint(w, getURL(r).ResolveReference(relativeURL).String())
+			fmt.Fprintln(w, getURL(r).ResolveReference(relativeURL).String())
 		}
 	}
 }


### PR DESCRIPTION
Sorry, also just noticed that you get the response urls concatenated with no separator when uploading multiple files.  That said this will also add a newline character that isn't currently there for POST only requests with one file.. it would be reasonable to avoid adding it on the last or always adding a newline event for PUT requests responses to be consistent.  What do you think? 
Thanks for the quick response on the other PR.
