### PR TITLE
update dockerfile 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@ extras
 build
 transfersh-server/run.sh
 .elasticbeanstalk
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7-alpine
+FROM golang:1.11-alpine as build
 LABEL maintainer="Remco Verhoef <remco@dutchcoders.io>"
 
 # Copy the local package files to the container's workspace.
@@ -7,6 +7,9 @@ ADD . /go/src/github.com/dutchcoders/transfer.sh
 # build & install server
 RUN go build -o /go/bin/transfersh github.com/dutchcoders/transfer.sh
 
-ENTRYPOINT ["/go/bin/transfersh", "--listener", ":8080", "--provider", "s3"]  
+FROM golang:1.11-alpine
+COPY --from=build /go/bin/transfersh /go/bin/transfersh
+
+ENTRYPOINT ["/go/bin/transfersh", "--listener", ":8080"]
 
 EXPOSE 8080 8080

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ aws-access-key | aws access key | | AWS_ACCESS_KEY
 aws-secret-key | aws access key | | AWS_SECRET_KEY
 bucket | aws bucket | | BUCKET
 basedir | path storage for local/gdrive provider| |
-gdrive-client-json-filepath | path to client json config for gdrive provider| |
-gdrive-local-config-path | path to local transfer.sh config cache for gdrive provider| |
+gdrive-client-json-filepath | path to oauth client json config for gdrive provider| |
+gdrive-local-config-path | path to store local transfer.sh config cache for gdrive provider| |
 lets-encrypt-hosts | hosts to use for lets encrypt certificates (comma seperated) | |
 log | path to log file| |
 


### PR DESCRIPTION
dockerfile: use multistage build, add dockerfile to ignore, bump golang version

gdrive(in readme.md): supports only oauth 2.0 client id json file for now