### PR TITLE
removed redundant parameter in expose instruction.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY --from=build /go/bin/transfersh /go/bin/transfersh
 
 ENTRYPOINT ["/go/bin/transfersh", "--listener", ":8080"]
 
-EXPOSE 8080 8080
+EXPOSE 8080


### PR DESCRIPTION
the second parameter in expose instruction is a noop and has no effect on published port.

https://docs.docker.com/engine/reference/builder/#expose
https://docs.docker.com/engine/reference/run/#expose-incoming-ports