### PR TITLE
Add second S3 Handler for Non-Multipart Uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src/
 bin/
 *.pyc
 *.egg-info/
+.idea/
 
 .tmp
 .vagrant

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ provider | which storage provider to use | (s3, grdrive or local) |
 aws-access-key | aws access key | | AWS_ACCESS_KEY
 aws-secret-key | aws access key | | AWS_SECRET_KEY
 bucket | aws bucket | | BUCKET
+s3-no-multipart | disables s3 multipart upload | false | |
 basedir | path storage for local/gdrive provider| |
 gdrive-client-json-filepath | path to oauth client json config for gdrive provider| |
 gdrive-local-config-path | path to store local transfer.sh config cache for gdrive provider| |

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,15 +2,13 @@ package cmd
 
 import (
 	"fmt"
-
+	"log"
 	"os"
-
 	"strings"
 
 	"github.com/dutchcoders/transfer.sh/server"
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"log"
 	"google.golang.org/api/googleapi"
 )
 
@@ -116,6 +114,10 @@ var globalFlags = []cli.Flag{
 		Usage:  "",
 		Value:  "",
 		EnvVar: "BUCKET",
+	},
+	cli.BoolFlag{
+		Name:  "no-multipart",
+		Usage: "Disables Multipart Puts",
 	},
 	cli.StringFlag{
 		Name:  "gdrive-client-json-filepath",
@@ -294,7 +296,7 @@ func New() *Cmd {
 				panic("secret-key not set.")
 			} else if bucket := c.String("bucket"); bucket == "" {
 				panic("bucket not set.")
-			} else if storage, err := server.NewS3Storage(accessKey, secretKey, bucket, c.String("s3-endpoint"), logger); err != nil {
+			} else if storage, err := server.NewS3Storage(accessKey, secretKey, bucket, c.String("s3-endpoint"), logger, c.Bool("no-multipart")); err != nil {
 				panic(err)
 			} else {
 				options = append(options, server.UseStorage(storage))

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -116,8 +116,8 @@ var globalFlags = []cli.Flag{
 		EnvVar: "BUCKET",
 	},
 	cli.BoolFlag{
-		Name:  "no-multipart",
-		Usage: "Disables Multipart Puts",
+		Name:  "s3-no-multipart",
+		Usage: "Disables S3 Multipart Puts",
 	},
 	cli.StringFlag{
 		Name:  "gdrive-client-json-filepath",
@@ -296,7 +296,7 @@ func New() *Cmd {
 				panic("secret-key not set.")
 			} else if bucket := c.String("bucket"); bucket == "" {
 				panic("bucket not set.")
-			} else if storage, err := server.NewS3Storage(accessKey, secretKey, bucket, c.String("s3-endpoint"), logger, c.Bool("no-multipart")); err != nil {
+			} else if storage, err := server.NewS3Storage(accessKey, secretKey, bucket, c.String("s3-endpoint"), logger, c.Bool("s3-no-multipart")); err != nil {
 				panic(err)
 			} else {
 				options = append(options, server.UseStorage(storage))

--- a/server/storage.go
+++ b/server/storage.go
@@ -129,13 +129,13 @@ type S3Storage struct {
 	noMultipart bool
 }
 
-func NewS3Storage(accessKey, secretKey, bucketName, endpoint string, logger *log.Logger, multipart bool) (*S3Storage, error) {
+func NewS3Storage(accessKey, secretKey, bucketName, endpoint string, logger *log.Logger, nomultipart bool) (*S3Storage, error) {
 	bucket, err := getBucket(accessKey, secretKey, bucketName, endpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	return &S3Storage{bucket: bucket, logger: logger, noMultipart: multipart}, nil
+	return &S3Storage{bucket: bucket, logger: logger, noMultipart: nomultipart}, nil
 }
 
 func (s *S3Storage) Type() string {

--- a/server/storage.go
+++ b/server/storage.go
@@ -318,7 +318,7 @@ func (s *S3Storage) Put(token string, filename string, reader io.Reader, content
 	key := fmt.Sprintf("%s/%s", token, filename)
 
 	s.logger.Printf("Uploading file %s to S3 Bucket", filename)
-	if s.noMultipart {
+	if !s.noMultipart {
 		err = s.putMulti(key, reader, contentType, contentLength)
 	} else {
 		err = s.bucket.PutReader(key, reader, int64(contentLength), contentType, s3.Private, s3.Options{})

--- a/server/storage.go
+++ b/server/storage.go
@@ -129,13 +129,13 @@ type S3Storage struct {
 	noMultipart bool
 }
 
-func NewS3Storage(accessKey, secretKey, bucketName, endpoint string, logger *log.Logger, nomultipart bool) (*S3Storage, error) {
+func NewS3Storage(accessKey, secretKey, bucketName, endpoint string, logger *log.Logger, disableMultipart bool) (*S3Storage, error) {
 	bucket, err := getBucket(accessKey, secretKey, bucketName, endpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	return &S3Storage{bucket: bucket, logger: logger, noMultipart: nomultipart}, nil
+	return &S3Storage{bucket: bucket, logger: logger, noMultipart: disableMultipart}, nil
 }
 
 func (s *S3Storage) Type() string {

--- a/server/storage.go
+++ b/server/storage.go
@@ -201,8 +201,7 @@ func (s *S3Storage) Delete(token string, filename string) (err error) {
 	return
 }
 
-func (s *S3Storage) PutMulti(token string, filename string, reader io.Reader, contentType string, contentLength uint64) (err error) {
-	key := fmt.Sprintf("%s/%s", token, filename)
+func (s *S3Storage) putMulti(key string, reader io.Reader, contentType string, contentLength uint64) (err error) {
 
 	var (
 		multi *s3.Multi
@@ -320,7 +319,7 @@ func (s *S3Storage) Put(token string, filename string, reader io.Reader, content
 
 	s.logger.Printf("Uploading file %s to S3 Bucket", filename)
 	if s.noMultipart {
-		err = s.PutMulti(token, filename, reader, contentType, contentLength)
+		err = s.putMulti(key, reader, contentType, contentLength)
 	} else {
 		err = s.bucket.PutReader(key, reader, int64(contentLength), contentType, s3.Private, s3.Options{})
 	}


### PR DESCRIPTION
With this small change, the service is able to upload to custom S3 Endpoints that dont fully support Multipart Uploads.

I added a flag to the runtime, to disable multipart uploads (which is the default and preferred way)