### PR TITLE
Fix the bash functions to handle files with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ X-Url-Delete: https://transfer.sh/hello.txt/BAYh0/hello.txt/PDw0NHPcqU
 ### Using curl
 ```bash
 transfer() {
-    curl --progress-bar --upload-file "$1" https://transfer.sh/$(basename $1) | tee /dev/null;
+    curl --progress-bar --upload-file "$1" https://transfer.sh/$(basename "$1") | tee /dev/null;
+    echo
 }
 
 alias transfer=transfer
@@ -72,7 +73,8 @@ alias transfer=transfer
 ### Using wget
 ```bash
 transfer() {
-    wget -t 1 -qO - --method=PUT --body-file="$1" --header="Content-Type: $(file -b --mime-type $1)" https://transfer.sh/$(basename $1);
+    wget -t 1 -qO - --method=PUT --body-file="$1" --header="Content-Type: $(file -b --mime-type "$1")" https://transfer.sh/$(basename "$1");
+    echo
 }
 
 alias transfer=transfer


### PR DESCRIPTION
Minor tweak to the example `transfer` bash functions to handle files with spaces.