### PR TITLE
Update Dockerfile generating smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
-FROM golang:1.12-alpine as build
-LABEL maintainer="Andrea Spacca <andrea.spacca@gmail.com>"
+# Default to Go 1.12
+ARG GO_VERSION=1.12
+FROM golang:${GO_VERSION}-alpine as build
 
-# Copy the local package files to the container's workspace.
+# Necessary to run 'go get' and to compile the linked binary
+RUN apk add git musl-dev
+
 ADD . /go/src/github.com/dutchcoders/transfer.sh
 
-# build & install server
-RUN go build -o /go/bin/transfersh github.com/dutchcoders/transfer.sh
+WORKDIR /go/src/github.com/dutchcoders/transfer.sh
 
-FROM golang:1.11-alpine
-COPY --from=build /go/bin/transfersh /go/bin/transfersh
+ENV GO111MODULE=on
+
+# build & install server
+RUN go get -u ./... && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags -a -tags netgo -ldflags '-w -extldflags "-static"' -o /go/bin/transfersh github.com/dutchcoders/transfer.sh
+
+FROM scratch AS final
+LABEL maintainer="Andrea Spacca <andrea.spacca@gmail.com>"
+
+COPY --from=build  /go/bin/transfersh /go/bin/transfersh
 
 ENTRYPOINT ["/go/bin/transfersh", "--listener", ":8080"]
 


### PR DESCRIPTION
Generate a statically linked binary, somewhat deal with issue #219.

As @n8225 didn't answer in more than a month I've improved the Dockerfile based on his changes.

The resulting image is considerably smaller:

```
dopessoa@local transfer.sh (master) $ docker images | grep transfer.sh
local/transfer.sh         latest              13186b203d06        9 minutes ago       15.4MB
dutchcoders/transfer.sh   latest              1ff531329501        4 months ago        325MB
```

Just bear in mind that the intermediary image get's to near 870MB.

An addition is that you can pass the Golang version of the build image using as a command line argument:

`docker build --build-arg GO_VERSION=1.11 .`

If no argument is present the default is 1.12.