### PR TITLE
Fix encoding of spaces in filenames from + to %20

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -328,7 +328,7 @@ func (s *Server) postHandler(w http.ResponseWriter, r *http.Request) {
 
 			}
 
-			filename = url.QueryEscape(filename)
+			filename = url.PathEscape(filename)
 			relativeURL, _ := url.Parse(path.Join(s.proxyPath, token, filename))
 			fmt.Fprintln(w, getURL(r).ResolveReference(relativeURL).String())
 
@@ -487,7 +487,7 @@ func (s *Server) putHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/plain")
 
-	filename = url.QueryEscape(filename)
+	filename = url.PathEscape(filename)
 	relativeURL, _ := url.Parse(path.Join(s.proxyPath, token, filename))
 	deleteURL, _ := url.Parse(path.Join(s.proxyPath, token, filename, metadata.DeletionToken))
 


### PR DESCRIPTION
Follow-up to #215/#216

Spaces in filenames are incorrectly encoded as `+` instead of `%20`:

    echo foo > 'a file'
    curl -v --upload-file 'a file' https://redacted/
    ...
    < X-Url-Delete: https://redacted/dcr2r/a+file/1pz0rU0YFu
    ...
    https://redacted/dcr2r/a+file

These URLs are 404s. The correct URLs are `https://redacted/dcr2r/a%20file/1pz0rU0YFu` and `https://redacted/dcr2r/a%20file`, respectively.