### PR TITLE
Add support for S3 path style URLS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ aws-secret-key | aws access key | | AWS_SECRET_KEY
 bucket | aws bucket | | BUCKET
 s3-region | region of the s3 bucket | eu-west-1 | S3_REGION
 s3-no-multipart | disables s3 multipart upload | false | |
+s3-path-style | Forces path style URLs, required for Minio. | false | |
 basedir | path storage for local/gdrive provider| |
 gdrive-client-json-filepath | path to oauth client json config for gdrive provider| |
 gdrive-local-config-path | path to store local transfer.sh config cache for gdrive provider| |

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -130,6 +130,10 @@ var globalFlags = []cli.Flag{
 		Name:  "s3-no-multipart",
 		Usage: "Disables S3 Multipart Puts",
 	},
+	cli.BoolFlag{
+		Name:  "s3-path-style",
+		Usage: "Forces path style URLs, required for Minio.",
+	},
 	cli.StringFlag{
 		Name:  "gdrive-client-json-filepath",
 		Usage: "",
@@ -339,7 +343,7 @@ func New() *Cmd {
 				panic("secret-key not set.")
 			} else if bucket := c.String("bucket"); bucket == "" {
 				panic("bucket not set.")
-			} else if storage, err := server.NewS3Storage(accessKey, secretKey, bucket, c.String("s3-region"), c.String("s3-endpoint"), logger, c.Bool("s3-no-multipart")); err != nil {
+			} else if storage, err := server.NewS3Storage(accessKey, secretKey, bucket, c.String("s3-region"), c.String("s3-endpoint"), logger, c.Bool("s3-no-multipart"), c.Bool("s3-path-style")); err != nil {
 				panic(err)
 			} else {
 				options = append(options, server.UseStorage(storage))

--- a/server/storage.go
+++ b/server/storage.go
@@ -3,10 +3,6 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"io"
 	"io/ioutil"
 	"log"
@@ -16,7 +12,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -132,8 +132,8 @@ type S3Storage struct {
 	noMultipart bool
 }
 
-func NewS3Storage(accessKey, secretKey, bucketName, region, endpoint string, logger *log.Logger, disableMultipart bool) (*S3Storage, error) {
-	sess := getAwsSession(accessKey, secretKey, region, endpoint)
+func NewS3Storage(accessKey, secretKey, bucketName, region, endpoint string, logger *log.Logger, disableMultipart bool, forcePathStyle bool) (*S3Storage, error) {
+	sess := getAwsSession(accessKey, secretKey, region, endpoint, forcePathStyle)
 
 	return &S3Storage{bucket: bucketName, s3: s3.New(sess), session: sess, logger: logger, noMultipart: disableMultipart}, nil
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -25,7 +25,6 @@ THE SOFTWARE.
 package server
 
 import (
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"math"
 	"net/http"
 	"net/mail"
@@ -33,15 +32,17 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/golang/gddo/httputil/header"
 )
 
-func getAwsSession(accessKey, secretKey, region, endpoint string) *session.Session {
+func getAwsSession(accessKey, secretKey, region, endpoint string, forcePathStyle bool) *session.Session {
 	return session.Must(session.NewSession(&aws.Config{
-		Region:      aws.String(region),
-		Endpoint:    aws.String(endpoint),
-		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, ""),
+		Region:           aws.String(region),
+		Endpoint:         aws.String(endpoint),
+		Credentials:      credentials.NewStaticCredentials(accessKey, secretKey, ""),
+		S3ForcePathStyle: aws.Bool(forcePathStyle),
 	}))
 }
 


### PR DESCRIPTION
Current support for Minio and possible other S3 providers is broken.  This PR adds the option to utilize path style URLs by setting `s3-path-style` to `true`, `s3-path-style` defaults to `false`.