### PR TITLE
Fix fish alias for busybox systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ alias transfer=transfer
 function transfer --description 'Upload a file to transfer.sh'
     if [ $argv[1] ]
         # write to output to tmpfile because of progress bar
-        set -l tmpfile ( mktemp -t transferXXX )
+        set -l tmpfile ( mktemp -t transferXXXXXX )
         curl --progress-bar --upload-file "$argv[1]" https://transfer.sh/(basename $argv[1]) >> $tmpfile
         cat $tmpfile
         command rm -f $tmpfile


### PR DESCRIPTION
While GNU mktemp will handle any number of X's, busybox mktemp (like in Android/Termux and distros like Alpine) insists on exactly 6 of them for whatever reason.