### PR TITLE
Fixes "mkdir /basedir: no such file or directory"

### DIFF
--- a/server/storage.go
+++ b/server/storage.go
@@ -106,7 +106,7 @@ func (s *LocalStorage) Put(token string, filename string, reader io.Reader, cont
 
 	path := filepath.Join(s.basedir, token)
 
-	if err = os.Mkdir(path, 0700); err != nil && !os.IsExist(err) {
+	if err = os.MkdirAll(path, 0700); err != nil && !os.IsExist(err) {
 		return err
 	}
 


### PR DESCRIPTION
If the basedir does not exist (like the case described on ISSUE #257), the Mkdir call fails.

Just changed to MkdirAll which creates the directories recursively.