### PR TITLE
use cryptographically secure rng seed

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,8 @@ import (
 	"errors"
 	gorillaHandlers "github.com/gorilla/handlers"
 	"log"
+	crypto_rand "crypto/rand"
+	"encoding/binary"
 	"math/rand"
 	"mime"
 	"net/http"
@@ -306,7 +308,11 @@ func New(options ...OptionFn) (*Server, error) {
 }
 
 func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
+	var seedBytes [8]byte
+	if _, err := crypto_rand.Read(seedBytes[:]); err != nil {
+		panic("cannot obtain cryptographically secure seed")
+	}
+	rand.Seed(int64(binary.LittleEndian.Uint64(seedBytes[:])))
 }
 
 func (s *Server) Run() {


### PR DESCRIPTION
This PR seeds math/random with a cryptographically secure 8 byte seed instead of a timestamp from the system.

System timestamps are generally discouraged for secure seeds because the high bits stay constant (and can be more easily guessed if you know when the program started). The low bits also are not reliable as the system clock on most systems does not actually have great reliability or precision at the nanosecond level.

This PR provides a seed with more entropy, pulling from the operating system's suggested source for cryptographically secure random numbers, rather than a more easily predictable timestamp.