### PR TITLE
ci: deploy multi-architecture Docker images using buildx

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,78 @@
+name: Deploy multi-architecture Docker images for transfer.sh with buildx
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # everyday at midnight UTC
+  pull_request:
+    branches: master
+  push:
+    branches: master
+    tags:
+      - v*
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Prepare
+        id: prepare
+        run: |
+          DOCKER_IMAGE=dutchcoders/transfer.sh
+          DOCKER_PLATFORMS=linux/amd64,linux/arm/v7,linux/arm64,linux/386
+          VERSION=edge
+
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
+
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            VERSION=nightly
+          fi
+
+          TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
+
+          if [ $VERSION = edge -o $VERSION = nightly ]; then
+            TAGS="$TAGS --tag ${DOCKER_IMAGE}:latest"
+          fi
+
+          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} \
+            --build-arg VERSION=${VERSION} \
+            --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+            --build-arg VCS_REF=${GITHUB_SHA::8} \
+            ${TAGS} .
+      -
+        name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+      -
+        name: Docker Buildx (build)
+        run: |
+          docker buildx build --no-cache --pull --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Docker Login
+        if: success() && github.event_name != 'pull_request'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      -
+        name: Docker Buildx (push)
+        if: success() && github.event_name != 'pull_request'
+        run: |
+          docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Docker Check Manifest
+        if: always() && github.event_name != 'pull_request'
+        run: |
+          docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+      -
+        name: Clear
+        if: always() && github.event_name != 'pull_request'
+        run: |
+          rm -f ${HOME}/.docker/config.json


### PR DESCRIPTION
This PR adds a GitHub action to build and deploy a multi-architecture Docker image to Docker hub. In order for this to work, 2 secrets need to be added to the `dutchcoders/transfer.sh` GitHub repository.

The first one called DOCKER_USERNAME should be the Docker hub username for the "dutchcoders" account.

The second one called DOCKER_PASSWORD should be an access token generated on Docker hub like explained [here](https://docs.docker.com/docker-hub/access-tokens/).

The images will be built for the following architectures:

* amd64 (x86_64)
* i386 (x86)
* armv8 (aarch64/arm64)
* armv7 (arm32)

The images will be built (and sometimes pushed) in the following circumstances:

* on pull requests (just built)
* on tag pushes when the tag matches: vX.Y.Z (built and pushed as `dutchcoders/transfer.sh:vX.Y.Z`)
* on pushes to master (built and pushed as `dutchcoders/transfer.sh:edge` and `dutchcoders/transfer.sh:latest`)
* every night at midnight UTC to pull in updates in the dependencies and the `golang` image (built  and pushed as `dutchcoders/transfer.sh:nightly` and `dutchcoders/transfer.sh:latest`)

This PR resolves #313.