### PR TITLE
Include version string in version command output

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -251,7 +251,7 @@ type Cmd struct {
 }
 
 func VersionAction(c *cli.Context) {
-	fmt.Println(color.YellowString(fmt.Sprintf("transfer.sh: Easy file sharing from the command line")))
+	fmt.Println(color.YellowString(fmt.Sprintf("transfer.sh %s: Easy file sharing from the command line", Version)))
 }
 
 func New() *Cmd {


### PR DESCRIPTION
The command `transfer.sh version` does not include the application's
version string in its output. Fix this.