### PR TITLE
ci: switch to official docker buildx GitHub action

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -47,8 +47,19 @@ jobs:
             --build-arg VCS_REF=${GITHUB_SHA::8} \
             ${TAGS} .
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      -
         name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      -
+        name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
       -
         name: Docker Buildx (build)
         run: |


### PR DESCRIPTION
Hello,

A few months back I added a GitHub action to build multi-architecture images using [this](https://github.com/crazy-max/ghaction-docker-buildx).

Since then, Docker has created an official GitHub action to do this.

This PR switches the GitHub to this new official one.