### PR TITLE
Run app with non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,12 @@ ENV GO111MODULE=on
 # build & install server
 RUN go get -u ./... && CGO_ENABLED=0 go build -ldflags -a -tags netgo -ldflags '-w -extldflags "-static"' -o /go/bin/transfersh github.com/dutchcoders/transfer.sh
 
-FROM scratch AS final
+FROM alpine AS final
 LABEL maintainer="Andrea Spacca <andrea.spacca@gmail.com>"
+
+# Creating a non-root user to run the software with
+RUN adduser --system app
+USER app
 
 COPY --from=build  /go/bin/transfersh /go/bin/transfersh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Running applications in Docker as root user opens various attack vectors, as Docker's "isolation" isn't meant to be the only safe guard against adversaries. It should be considered a "last resort". It's best practice to use a non-root user wherever possible.

This commit changes back to Alpine as a base, as it provides the adduser tool via busybox. It increases the image size by a few MiB (2-3, currently). One could optimize the image size by writing a custom `/etc/passwd`, but this seems quite unnecessary, especially given that Alpine is the base of so many other images.