### PR TITLE
Only rewrite metadata file when the download counter changed

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -661,13 +661,11 @@ func (s *Server) CheckMetadata(token, filename string, increaseDownload bool) (M
 		return metadata, errors.New("MaxDownloads expired.")
 	} else if !metadata.MaxDate.IsZero() && time.Now().After(metadata.MaxDate) {
 		return metadata, errors.New("MaxDate expired.")
-	} else {
+	} else if increaseDownload {
 		// todo(nl5887): mutex?
 
 		// update number of downloads
-		if increaseDownload {
-			metadata.Downloads++
-		}
+		metadata.Downloads++
 
 		buffer := &bytes.Buffer{}
 		if err := json.NewEncoder(buffer).Encode(metadata); err != nil {


### PR DESCRIPTION
Previously, the metadata file would be rewritten even if the download counter stayed the same (i.e. `increaseDownload = false`, previews and HEAD requests). Because the metadata doesn't change in that case, this would simply rewrite the exact same contents needlessly, which may also incur extra costs depending on the storage backend.