### PR TITLE
Only increment download counter on files that have a download limit

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -661,7 +661,7 @@ func (s *Server) CheckMetadata(token, filename string, increaseDownload bool) (M
 		return metadata, errors.New("MaxDownloads expired.")
 	} else if !metadata.MaxDate.IsZero() && time.Now().After(metadata.MaxDate) {
 		return metadata, errors.New("MaxDate expired.")
-	} else if increaseDownload {
+	} else if metadata.MaxDownloads != -1 && increaseDownload {
 		// todo(nl5887): mutex?
 
 		// update number of downloads


### PR DESCRIPTION
For files that have no limit, there is no reason to track the download counter as its value will never be used anyway. This reduces costs on storage backends that have an operation fee (e.g. AWS S3) or a minimum retention (e.g. Wasabi S3).

Fixes #364