### PR TITLE
Added support for markdown-autodocs

### DIFF
--- a/.github/workflows/markdown-autodocs.yml
+++ b/.github/workflows/markdown-autodocs.yml
@@ -1,0 +1,14 @@
+name: markdown-autodocs
+
+on:
+  push:
+    branches:    
+      - '**'        # matches every branch
+
+jobs:        
+  auto-update-readme:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Markdown autodocs
+          uses: dineshsonachalam/markdown-autodocs@v1.0.2

--- a/README.md
+++ b/README.md
@@ -11,51 +11,42 @@ The service at https://transfersh.com is of unknown origin and reported as cloud
 ## Usage
 
 ### Upload:
-```bash
-$ curl --upload-file ./hello.txt https://transfer.sh/hello.txt
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/upload.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ### Encrypt & upload:
-```bash
-$ cat /tmp/hello.txt|gpg -ac -o-|curl -X PUT --upload-file "-" https://transfer.sh/test.txt
-````
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/encrypt-and-upload.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ### Download & decrypt:
-```bash
-$ curl https://transfer.sh/1lDau/test.txt|gpg -o- > /tmp/hello.txt
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/download-and-decrypt.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ### Upload to virustotal:
-```bash
-$ curl -X PUT --upload-file nhgbhhj https://transfer.sh/test.txt/virustotal
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/upload-to-virustotal.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ### Deleting
-```bash
-$ curl -X DELETE <X-Url-Delete Response Header URL>
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/deleting.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Request Headers
 
 ### Max-Downloads
-```bash
-$ curl --upload-file ./hello.txt https://transfer.sh/hello.txt -H "Max-Downloads: 1" # Limit the number of downloads
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/max-downloads.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ### Max-Days
-```bash
-$ curl --upload-file ./hello.txt https://transfer.sh/hello.txt -H "Max-Days: 1" # Set the number of days before deletion
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/max-days.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Response Headers
 
 ### X-Url-Delete
 
 The URL used to request the deletion of a file. Returned as a response header.
-```bash
-curl -sD - --upload-file ./hello https://transfer.sh/hello.txt | grep 'X-Url-Delete'
-X-Url-Delete: https://transfer.sh/hello.txt/BAYh0/hello.txt/PDw0NHPcqU
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/x-url-delete.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Examples
 
@@ -73,48 +64,8 @@ https://transfer.sh/1lDau/test.txt --> https://transfer.sh/inline/1lDau/test.txt
 
 ## Usage
 
-Parameter | Description | Value | Env
---- | --- | --- | ---
-listener | port to use for http (:80) | | LISTENER |
-profile-listener | port to use for profiler (:6060) | | PROFILE_LISTENER |
-force-https | redirect to https | false | FORCE_HTTPS
-tls-listener | port to use for https (:443) | | TLS_LISTENER |
-tls-listener-only | flag to enable tls listener only | | TLS_LISTENER_ONLY |
-tls-cert-file | path to tls certificate | | TLS_CERT_FILE |
-tls-private-key | path to tls private key | | TLS_PRIVATE_KEY |
-http-auth-user | user for basic http auth on upload | | HTTP_AUTH_USER |
-http-auth-pass | pass for basic http auth on upload | | HTTP_AUTH_PASS |
-ip-whitelist | comma separated list of ips allowed to connect to the service | | IP_WHITELIST |
-ip-blacklist | comma separated list of ips not allowed to connect to the service | | IP_BLACKLIST |
-temp-path | path to temp folder | system temp | TEMP_PATH |
-web-path | path to static web files (for development or custom front end) | | WEB_PATH |
-proxy-path | path prefix when service is run behind a proxy | | PROXY_PATH |
-proxy-port | port of the proxy when the service is run behind a proxy | | PROXY_PORT |
-ga-key | google analytics key for the front end | | GA_KEY |
-provider | which storage provider to use | (s3, storj, gdrive or local) |
-uservoice-key | user voice key for the front end  | | USERVOICE_KEY |
-aws-access-key | aws access key | | AWS_ACCESS_KEY |
-aws-secret-key | aws access key | | AWS_SECRET_KEY |
-bucket | aws bucket | | BUCKET |
-s3-endpoint | Custom S3 endpoint. | | S3_ENDPOINT |
-s3-region | region of the s3 bucket | eu-west-1 | S3_REGION |
-s3-no-multipart | disables s3 multipart upload | false | S3_NO_MULTIPART |
-s3-path-style | Forces path style URLs, required for Minio. | false | S3_PATH_STYLE |
-storj-access | Access for the project | | STORJ_ACCESS |
-storj-bucket | Bucket to use within the project | | STORJ_BUCKET |
-basedir | path storage for local/gdrive provider | | BASEDIR |
-gdrive-client-json-filepath | path to oauth client json config for gdrive provider | | GDRIVE_CLIENT_JSON_FILEPATH |
-gdrive-local-config-path | path to store local transfer.sh config cache for gdrive provider| | GDRIVE_LOCAL_CONFIG_PATH |
-gdrive-chunk-size | chunk size for gdrive upload in megabytes, must be lower than available memory (8 MB) | | GDRIVE_CHUNK_SIZE |
-lets-encrypt-hosts | hosts to use for lets encrypt certificates (comma seperated) | | HOSTS |
-log | path to log file| | LOG |
-cors-domains | comma separated list of domains for CORS, setting it enable CORS | | CORS_DOMAINS |
-clamav-host | host for clamav feature  | | CLAMAV_HOST |
-rate-limit | request per minute  | | RATE_LIMIT |
-max-upload-size | max upload size in kilobytes  | | MAX_UPLOAD_SIZE |
-purge-days | number of days after the uploads are purged automatically | | PURGE_DAYS |   
-purge-interval | interval in hours to run the automatic purge for (not applicable to S3 and Storj) | | PURGE_INTERVAL |   
-random-token-length | length of the random token for the upload path (double the size for delete path) | 6 | RANDOM_TOKEN_LENGTH |   
+<!-- MARKDOWN-AUTO-DOCS:START (JSON_TO_HTML_TABLE:src=./examples/readme/usage.json) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->   
 
 If you want to use TLS using lets encrypt certificates, set lets-encrypt-hosts to your domain, set tls-listener to :443 and enable force-https.
 
@@ -123,26 +74,18 @@ If you want to use TLS using your own certificates, set tls-listener to :443, fo
 ## Development
 
 Switched to GO111MODULE
-
-```bash
-go run main.go --provider=local --listener :8080 --temp-path=/tmp/ --basedir=/tmp/
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/dev.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Build
-
-```bash
-$ git clone git@github.com:dutchcoders/transfer.sh.git
-$ cd transfer.sh
-$ go build -o transfersh main.go
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/build.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Docker
 
 For easy deployment, we've created a Docker container.
-
-```bash
-docker run --publish 8080:8080 dutchcoders/transfer.sh:latest --provider local --basedir /tmp/
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/docker-run.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## S3 Usage
 
@@ -200,8 +143,8 @@ You need to create a Oauth Client id from console.cloud.google.com
 download the file and place into a safe directory
 
 ### Usage example
-
-```go run main.go --provider gdrive --basedir /tmp/ --gdrive-client-json-filepath /[credential_dir] --gdrive-local-config-path [directory_to_save_config] ```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/usage-example.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -12,32 +12,60 @@ The service at https://transfersh.com is of unknown origin and reported as cloud
 
 ### Upload:
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/upload.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/upload.sh -->
+```sh
+curl --upload-file ./hello.txt https://transfer.sh/hello.txt
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ### Encrypt & upload:
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/encrypt-and-upload.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/encrypt-and-upload.sh -->
+```sh
+cat /tmp/hello.txt|gpg -ac -o-|curl -X PUT --upload-file "-" https://transfer.sh/test.txt
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ### Download & decrypt:
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/download-and-decrypt.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/download-and-decrypt.sh -->
+```sh
+curl https://transfer.sh/1lDau/test.txt|gpg -o- > /tmp/hello.txt
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ### Upload to virustotal:
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/upload-to-virustotal.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/upload-to-virustotal.sh -->
+```sh
+curl -X PUT --upload-file nhgbhhj https://transfer.sh/test.txt/virustotal
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ### Deleting
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/deleting.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/deleting.sh -->
+```sh
+curl -X DELETE <X-Url-Delete Response Header URL>
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Request Headers
 
 ### Max-Downloads
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/max-downloads.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/max-downloads.sh -->
+```sh
+curl --upload-file ./hello.txt https://transfer.sh/hello.txt -H "Max-Downloads: 1" # Limit the number of downloads
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ### Max-Days
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/max-days.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/max-days.sh -->
+```sh
+curl --upload-file ./hello.txt https://transfer.sh/hello.txt -H "Max-Days: 1" # Set the number of days before deletion
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Response Headers
@@ -46,6 +74,11 @@ The service at https://transfersh.com is of unknown origin and reported as cloud
 
 The URL used to request the deletion of a file. Returned as a response header.
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/x-url-delete.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/x-url-delete.sh -->
+```sh
+curl -sD - --upload-file ./hello https://transfer.sh/hello.txt | grep 'X-Url-Delete'
+X-Url-Delete: https://transfer.sh/hello.txt/BAYh0/hello.txt/PDw0NHPcqU
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Examples
@@ -65,6 +98,46 @@ https://transfer.sh/1lDau/test.txt --> https://transfer.sh/inline/1lDau/test.txt
 ## Usage
 
 <!-- MARKDOWN-AUTO-DOCS:START (JSON_TO_HTML_TABLE:src=./examples/readme/usage.json) -->
+<table class="JSON-TO-HTML-TABLE"><thead><tr><th class="parameter-th">Parameter</th><th class="description-th">Description</th><th class="value-th">Value</th><th class="env-th">Env</th></tr></thead><tbody ><tr ><td class="parameter-td td_text">listener</td><td class="description-td td_text">port to use for http (:80)</td><td class="value-td td_num"></td><td class="env-td td_text">LISTENER</td></tr>
+<tr ><td class="parameter-td td_text">profile-listener</td><td class="description-td td_text">port to use for profiler (:6060)</td><td class="value-td td_num"></td><td class="env-td td_text">PROFILE_LISTENER</td></tr>
+<tr ><td class="parameter-td td_text">force-https</td><td class="description-td td_text">redirect to https</td><td class="value-td td_text">false</td><td class="env-td td_text">FORCE_HTTPS</td></tr>
+<tr ><td class="parameter-td td_text">tls-listener</td><td class="description-td td_text">port to use for https (:443)</td><td class="value-td td_num"></td><td class="env-td td_text">TLS_LISTENER</td></tr>
+<tr ><td class="parameter-td td_text">tls-listener-only</td><td class="description-td td_text">flag to enable tls listener only</td><td class="value-td td_num"></td><td class="env-td td_text">TLS_LISTENER_ONLY</td></tr>
+<tr ><td class="parameter-td td_text">tls-cert-file</td><td class="description-td td_text">path to tls certificate</td><td class="value-td td_num"></td><td class="env-td td_text">TLS_CERT_FILE</td></tr>
+<tr ><td class="parameter-td td_text">tls-private-key</td><td class="description-td td_text">path to tls private key</td><td class="value-td td_num"></td><td class="env-td td_text">TLS_PRIVATE_KEY</td></tr>
+<tr ><td class="parameter-td td_text">http-auth-user</td><td class="description-td td_text">user for basic http auth on upload</td><td class="value-td td_num"></td><td class="env-td td_text">HTTP_AUTH_USER</td></tr>
+<tr ><td class="parameter-td td_text">http-auth-pass</td><td class="description-td td_text">pass for basic http auth on upload</td><td class="value-td td_num"></td><td class="env-td td_text">HTTP_AUTH_PASS</td></tr>
+<tr ><td class="parameter-td td_text">ip-whitelist</td><td class="description-td td_text">comma separated list of ips allowed to connect to the service</td><td class="value-td td_num"></td><td class="env-td td_text">IP_WHITELIST</td></tr>
+<tr ><td class="parameter-td td_text">ip-blacklist</td><td class="description-td td_text">comma separated list of ips not allowed to connect to the service</td><td class="value-td td_num"></td><td class="env-td td_text">IP_BLACKLIST</td></tr>
+<tr ><td class="parameter-td td_text">temp-path</td><td class="description-td td_text">path to temp folder</td><td class="value-td td_text">system temp</td><td class="env-td td_text">TEMP_PATH</td></tr>
+<tr ><td class="parameter-td td_text">web-path</td><td class="description-td td_text">path to static web files (for development or custom front end)</td><td class="value-td td_num"></td><td class="env-td td_text">WEB_PATH</td></tr>
+<tr ><td class="parameter-td td_text">proxy-path</td><td class="description-td td_text">path prefix when service is run behind a proxy</td><td class="value-td td_num"></td><td class="env-td td_text">PROXY_PATH</td></tr>
+<tr ><td class="parameter-td td_text">proxy-port</td><td class="description-td td_text">port of the proxy when the service is run behind a proxy</td><td class="value-td td_num"></td><td class="env-td td_text">PROXY_PORT</td></tr>
+<tr ><td class="parameter-td td_text">ga-key</td><td class="description-td td_text">google analytics key for the front end</td><td class="value-td td_num"></td><td class="env-td td_text">GA_KEY</td></tr>
+<tr ><td class="parameter-td td_text">provider</td><td class="description-td td_text">which storage provider to use</td><td class="value-td td_text">(s3, storj, gdrive or local)</td><td class="env-td td_num"></td></tr>
+<tr ><td class="parameter-td td_text">uservoice-key</td><td class="description-td td_text">user voice key for the front end</td><td class="value-td td_num"></td><td class="env-td td_text">USERVOICE_KEY</td></tr>
+<tr ><td class="parameter-td td_text">aws-access-key</td><td class="description-td td_text">aws access key</td><td class="value-td td_num"></td><td class="env-td td_text">AWS_ACCESS_KEY</td></tr>
+<tr ><td class="parameter-td td_text">aws-secret-key</td><td class="description-td td_text">aws access key</td><td class="value-td td_num"></td><td class="env-td td_text">AWS_SECRET_KEY</td></tr>
+<tr ><td class="parameter-td td_text">bucket</td><td class="description-td td_text">aws bucket</td><td class="value-td td_num"></td><td class="env-td td_text">BUCKET</td></tr>
+<tr ><td class="parameter-td td_text">s3-endpoint</td><td class="description-td td_text">Custom S3 endpoint.</td><td class="value-td td_num"></td><td class="env-td td_text">S3_ENDPOINT</td></tr>
+<tr ><td class="parameter-td td_text">s3-region</td><td class="description-td td_text">region of the s3 bucket</td><td class="value-td td_text">eu-west-1</td><td class="env-td td_text">S3_REGION</td></tr>
+<tr ><td class="parameter-td td_text">s3-no-multipart</td><td class="description-td td_text">disables s3 multipart upload</td><td class="value-td td_text">false</td><td class="env-td td_text">S3_NO_MULTIPART</td></tr>
+<tr ><td class="parameter-td td_text">s3-path-style</td><td class="description-td td_text">Forces path style URLs, required for Minio.</td><td class="value-td td_text">false</td><td class="env-td td_text">S3_PATH_STYLE</td></tr>
+<tr ><td class="parameter-td td_text">storj-access</td><td class="description-td td_text">Access for the project</td><td class="value-td td_num"></td><td class="env-td td_text">STORJ_ACCESS</td></tr>
+<tr ><td class="parameter-td td_text">storj-bucket</td><td class="description-td td_text">Bucket to use within the project</td><td class="value-td td_num"></td><td class="env-td td_text">STORJ_BUCKET</td></tr>
+<tr ><td class="parameter-td td_text">basedir</td><td class="description-td td_text">path storage for local/gdrive provider</td><td class="value-td td_num"></td><td class="env-td td_text">BASEDIR</td></tr>
+<tr ><td class="parameter-td td_text">gdrive-client-json-filepath</td><td class="description-td td_text">path to oauth client json config for gdrive provider</td><td class="value-td td_num"></td><td class="env-td td_text">GDRIVE_CLIENT_JSON_FILEPATH</td></tr>
+<tr ><td class="parameter-td td_text">gdrive-local-config-path</td><td class="description-td td_text">path to store local transfer.sh config cache for gdrive provider</td><td class="value-td td_num"></td><td class="env-td td_text">GDRIVE_LOCAL_CONFIG_PATH</td></tr>
+<tr ><td class="parameter-td td_text">gdrive-chunk-size</td><td class="description-td td_text">chunk size for gdrive upload in megabytes, must be lower than available memory (8 MB)</td><td class="value-td td_num"></td><td class="env-td td_text">GDRIVE_CHUNK_SIZE</td></tr>
+<tr ><td class="parameter-td td_text">lets-encrypt-hosts</td><td class="description-td td_text">hosts to use for lets encrypt certificates (comma seperated)</td><td class="value-td td_num"></td><td class="env-td td_text">HOSTS</td></tr>
+<tr ><td class="parameter-td td_text">log</td><td class="description-td td_text">path to log file</td><td class="value-td td_num"></td><td class="env-td td_text">LOG</td></tr>
+<tr ><td class="parameter-td td_text">cors-domains</td><td class="description-td td_text">comma separated list of domains for CORS, setting it enable CORS</td><td class="value-td td_num"></td><td class="env-td td_text">CORS_DOMAINS</td></tr>
+<tr ><td class="parameter-td td_text">clamav-host</td><td class="description-td td_text">host for clamav feature</td><td class="value-td td_num"></td><td class="env-td td_text">CLAMAV_HOST</td></tr>
+<tr ><td class="parameter-td td_text">rate-limit</td><td class="description-td td_text">request per minute</td><td class="value-td td_num"></td><td class="env-td td_text">RATE_LIMIT</td></tr>
+<tr ><td class="parameter-td td_text">max-upload-size</td><td class="description-td td_text">max upload size in kilobytes</td><td class="value-td td_num"></td><td class="env-td td_text">MAX_UPLOAD_SIZE</td></tr>
+<tr ><td class="parameter-td td_text">purge-days</td><td class="description-td td_text">number of days after the uploads are purged automatically</td><td class="value-td td_num"></td><td class="env-td td_text">PURGE_DAYS</td></tr>
+<tr ><td class="parameter-td td_text">purge-interval</td><td class="description-td td_text">interval in hours to run the automatic purge for (not applicable to S3 and Storj)</td><td class="value-td td_num"></td><td class="env-td td_text">PURGE_INTERVAL</td></tr>
+<tr ><td class="parameter-td td_text">random-token-length</td><td class="description-td td_text">length of the random token for the upload path (double the size for delete path)</td><td class="value-td td_num">6</td><td class="env-td td_text">RANDOM_TOKEN_LENGTH</td></tr></tbody></table>
 <!-- MARKDOWN-AUTO-DOCS:END -->   
 
 If you want to use TLS using lets encrypt certificates, set lets-encrypt-hosts to your domain, set tls-listener to :443 and enable force-https.
@@ -75,16 +148,30 @@ If you want to use TLS using your own certificates, set tls-listener to :443, fo
 
 Switched to GO111MODULE
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/dev.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/dev.sh -->
+```sh
+go run main.go --provider=local --listener :8080 --temp-path=/tmp/ --basedir=/tmp/
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Build
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/build.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/build.sh -->
+```sh
+git clone git@github.com:dutchcoders/transfer.sh.git
+cd transfer.sh
+go build -o transfersh main.go
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Docker
 
 For easy deployment, we've created a Docker container.
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/docker-run.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/docker-run.sh -->
+```sh
+docker run --publish 8080:8080 dutchcoders/transfer.sh:latest --provider local --basedir /tmp/
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## S3 Usage
@@ -144,6 +231,10 @@ download the file and place into a safe directory
 
 ### Usage example
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/usage-example.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/usage-example.sh -->
+```sh
+go run main.go --provider gdrive --basedir /tmp/ --gdrive-client-json-filepath /[credential_dir] --gdrive-local-config-path [directory_to_save_config]
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Contributions

--- a/examples/readme/build.sh
+++ b/examples/readme/build.sh
@@ -1,0 +1,3 @@
+git clone git@github.com:dutchcoders/transfer.sh.git
+cd transfer.sh
+go build -o transfersh main.go

--- a/examples/readme/deleting.sh
+++ b/examples/readme/deleting.sh
@@ -1,0 +1,1 @@
+curl -X DELETE <X-Url-Delete Response Header URL>

--- a/examples/readme/dev.sh
+++ b/examples/readme/dev.sh
@@ -1,0 +1,1 @@
+go run main.go --provider=local --listener :8080 --temp-path=/tmp/ --basedir=/tmp/

--- a/examples/readme/docker-run.sh
+++ b/examples/readme/docker-run.sh
@@ -1,0 +1,1 @@
+docker run --publish 8080:8080 dutchcoders/transfer.sh:latest --provider local --basedir /tmp/

--- a/examples/readme/download-and-decrypt.sh
+++ b/examples/readme/download-and-decrypt.sh
@@ -1,0 +1,1 @@
+curl https://transfer.sh/1lDau/test.txt|gpg -o- > /tmp/hello.txt

--- a/examples/readme/encrypt-and-upload.sh
+++ b/examples/readme/encrypt-and-upload.sh
@@ -1,0 +1,1 @@
+cat /tmp/hello.txt|gpg -ac -o-|curl -X PUT --upload-file "-" https://transfer.sh/test.txt

--- a/examples/readme/max-days.sh
+++ b/examples/readme/max-days.sh
@@ -1,0 +1,1 @@
+curl --upload-file ./hello.txt https://transfer.sh/hello.txt -H "Max-Days: 1" # Set the number of days before deletion

--- a/examples/readme/max-downloads.sh
+++ b/examples/readme/max-downloads.sh
@@ -1,0 +1,1 @@
+curl --upload-file ./hello.txt https://transfer.sh/hello.txt -H "Max-Downloads: 1" # Limit the number of downloads

--- a/examples/readme/upload-to-virustotal.sh
+++ b/examples/readme/upload-to-virustotal.sh
@@ -1,0 +1,1 @@
+curl -X PUT --upload-file nhgbhhj https://transfer.sh/test.txt/virustotal

--- a/examples/readme/upload.sh
+++ b/examples/readme/upload.sh
@@ -1,0 +1,1 @@
+curl --upload-file ./hello.txt https://transfer.sh/hello.txt

--- a/examples/readme/usage-example.sh
+++ b/examples/readme/usage-example.sh
@@ -1,0 +1,1 @@
+go run main.go --provider gdrive --basedir /tmp/ --gdrive-client-json-filepath /[credential_dir] --gdrive-local-config-path [directory_to_save_config] 

--- a/examples/readme/usage.json
+++ b/examples/readme/usage.json
@@ -1,0 +1,242 @@
+[
+    {
+        "Parameter": "listener",
+        "Description": "port to use for http (:80)",
+        "Value": "",
+        "Env": "LISTENER"
+    },
+    {
+        "Parameter": "profile-listener",
+        "Description": "port to use for profiler (:6060)",
+        "Value": "",
+        "Env": "PROFILE_LISTENER"
+    },
+    {
+        "Parameter": "force-https",
+        "Description": "redirect to https",
+        "Value": "false",
+        "Env": "FORCE_HTTPS"
+    },
+    {
+        "Parameter": "tls-listener",
+        "Description": "port to use for https (:443)",
+        "Value": "",
+        "Env": "TLS_LISTENER"
+    },
+    {
+        "Parameter": "tls-listener-only",
+        "Description": "flag to enable tls listener only",
+        "Value": "",
+        "Env": "TLS_LISTENER_ONLY"
+    },
+    {
+        "Parameter": "tls-cert-file",
+        "Description": "path to tls certificate",
+        "Value": "",
+        "Env": "TLS_CERT_FILE"
+    },
+    {
+        "Parameter": "tls-private-key",
+        "Description": "path to tls private key",
+        "Value": "",
+        "Env": "TLS_PRIVATE_KEY"
+    },
+    {
+        "Parameter": "http-auth-user",
+        "Description": "user for basic http auth on upload",
+        "Value": "",
+        "Env": "HTTP_AUTH_USER"
+    },
+    {
+        "Parameter": "http-auth-pass",
+        "Description": "pass for basic http auth on upload",
+        "Value": "",
+        "Env": "HTTP_AUTH_PASS"
+    },
+    {
+        "Parameter": "ip-whitelist",
+        "Description": "comma separated list of ips allowed to connect to the service",
+        "Value": "",
+        "Env": "IP_WHITELIST"
+    },
+    {
+        "Parameter": "ip-blacklist",
+        "Description": "comma separated list of ips not allowed to connect to the service",
+        "Value": "",
+        "Env": "IP_BLACKLIST"
+    },
+    {
+        "Parameter": "temp-path",
+        "Description": "path to temp folder",
+        "Value": "system temp",
+        "Env": "TEMP_PATH"
+    },
+    {
+        "Parameter": "web-path",
+        "Description": "path to static web files (for development or custom front end)",
+        "Value": "",
+        "Env": "WEB_PATH"
+    },
+    {
+        "Parameter": "proxy-path",
+        "Description": "path prefix when service is run behind a proxy",
+        "Value": "",
+        "Env": "PROXY_PATH"
+    },
+    {
+        "Parameter": "proxy-port",
+        "Description": "port of the proxy when the service is run behind a proxy",
+        "Value": "",
+        "Env": "PROXY_PORT"
+    },
+    {
+        "Parameter": "ga-key",
+        "Description": "google analytics key for the front end",
+        "Value": "",
+        "Env": "GA_KEY"
+    },
+    {
+        "Parameter": "provider",
+        "Description": "which storage provider to use",
+        "Value": "(s3, storj, gdrive or local)",
+        "Env": ""
+    },
+    {
+        "Parameter": "uservoice-key",
+        "Description": "user voice key for the front end",
+        "Value": "",
+        "Env": "USERVOICE_KEY"
+    },
+    {
+        "Parameter": "aws-access-key",
+        "Description": "aws access key",
+        "Value": "",
+        "Env": "AWS_ACCESS_KEY"
+    },
+    {
+        "Parameter": "aws-secret-key",
+        "Description": "aws access key",
+        "Value": "",
+        "Env": "AWS_SECRET_KEY"
+    },
+    {
+        "Parameter": "bucket",
+        "Description": "aws bucket",
+        "Value": "",
+        "Env": "BUCKET"
+    },
+    {
+        "Parameter": "s3-endpoint",
+        "Description": "Custom S3 endpoint.",
+        "Value": "",
+        "Env": "S3_ENDPOINT"
+    },
+    {
+        "Parameter": "s3-region",
+        "Description": "region of the s3 bucket",
+        "Value": "eu-west-1",
+        "Env": "S3_REGION"
+    },
+    {
+        "Parameter": "s3-no-multipart",
+        "Description": "disables s3 multipart upload",
+        "Value": "false",
+        "Env": "S3_NO_MULTIPART"
+    },
+    {
+        "Parameter": "s3-path-style",
+        "Description": "Forces path style URLs, required for Minio.",
+        "Value": "false",
+        "Env": "S3_PATH_STYLE"
+    },
+    {
+        "Parameter": "storj-access",
+        "Description": "Access for the project",
+        "Value": "",
+        "Env": "STORJ_ACCESS"
+    },
+    {
+        "Parameter": "storj-bucket",
+        "Description": "Bucket to use within the project",
+        "Value": "",
+        "Env": "STORJ_BUCKET"
+    },
+    {
+        "Parameter": "basedir",
+        "Description": "path storage for local/gdrive provider",
+        "Value": "",
+        "Env": "BASEDIR"
+    },
+    {
+        "Parameter": "gdrive-client-json-filepath",
+        "Description": "path to oauth client json config for gdrive provider",
+        "Value": "",
+        "Env": "GDRIVE_CLIENT_JSON_FILEPATH"
+    },
+    {
+        "Parameter": "gdrive-local-config-path",
+        "Description": "path to store local transfer.sh config cache for gdrive provider",
+        "Value": "",
+        "Env": "GDRIVE_LOCAL_CONFIG_PATH"
+    },
+    {
+        "Parameter": "gdrive-chunk-size",
+        "Description": "chunk size for gdrive upload in megabytes, must be lower than available memory (8 MB)",
+        "Value": "",
+        "Env": "GDRIVE_CHUNK_SIZE"
+    },
+    {
+        "Parameter": "lets-encrypt-hosts",
+        "Description": "hosts to use for lets encrypt certificates (comma seperated)",
+        "Value": "",
+        "Env": "HOSTS"
+    },
+    {
+        "Parameter": "log",
+        "Description": "path to log file",
+        "Value": "",
+        "Env": "LOG"
+    },
+    {
+        "Parameter": "cors-domains",
+        "Description": "comma separated list of domains for CORS, setting it enable CORS",
+        "Value": "",
+        "Env": "CORS_DOMAINS"
+    },
+    {
+        "Parameter": "clamav-host",
+        "Description": "host for clamav feature",
+        "Value": "",
+        "Env": "CLAMAV_HOST"
+    },
+    {
+        "Parameter": "rate-limit",
+        "Description": "request per minute",
+        "Value": "",
+        "Env": "RATE_LIMIT"
+    },
+    {
+        "Parameter": "max-upload-size",
+        "Description": "max upload size in kilobytes",
+        "Value": "",
+        "Env": "MAX_UPLOAD_SIZE"
+    },
+    {
+        "Parameter": "purge-days",
+        "Description": "number of days after the uploads are purged automatically",
+        "Value": "",
+        "Env": "PURGE_DAYS"
+    },
+    {
+        "Parameter": "purge-interval",
+        "Description": "interval in hours to run the automatic purge for (not applicable to S3 and Storj)",
+        "Value": "",
+        "Env": "PURGE_INTERVAL"
+    },
+    {
+        "Parameter": "random-token-length",
+        "Description": "length of the random token for the upload path (double the size for delete path)",
+        "Value": "6",
+        "Env": "RANDOM_TOKEN_LENGTH"
+    }
+]

--- a/examples/readme/x-url-delete.sh
+++ b/examples/readme/x-url-delete.sh
@@ -1,0 +1,2 @@
+curl -sD - --upload-file ./hello https://transfer.sh/hello.txt | grep 'X-Url-Delete'
+X-Url-Delete: https://transfer.sh/hello.txt/BAYh0/hello.txt/PDw0NHPcqU


### PR DESCRIPTION
## Problem with updating Code block or Markdown tables in your README.md 

To make your repo more appealing and, useful you need to provide Table or example code snippets in your README.md. Manually copy and pasting each code snippet or adding a table row in their respective places in your README would be inefficient and time-consuming.

## Solution to this problem:

This problem can be solved using markdown-autodocs GitHub Action that is created by me that automatically generates & updates markdown content (like your README.md) from external or remote files. You need to add markers in your README.md that will tell markdown-autodocs where to insert the code snippet or transform JSON to HTML table.

Markdown Autodocs GitHub action: https://github.com/dineshsonachalam/markdown-autodocs

To test or experiment markdown-autodocs without Github action: https://github.com/dineshsonachalam/markdown-autodocs#local-usage-without-github-action

Please let me know if any changes are required and will be happy to help.
cc: @nl5887 