### PR TITLE
Docker: Allow selection of (unprivileged) UID/GID at build time

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -34,9 +34,11 @@ jobs:
           fi
 
           TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
+          TAGS_NOROOT="--tag ${DOCKER_IMAGE}:${VERSION}-noroot"
 
           if [ $VERSION = edge -o $VERSION = nightly ]; then
             TAGS="$TAGS --tag ${DOCKER_IMAGE}:latest"
+            TAGS_NOROOT="$TAGS_NOROOT --tag ${DOCKER_IMAGE}:latest-noroot"
           fi
 
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
@@ -46,6 +48,12 @@ jobs:
             --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
             --build-arg VCS_REF=${GITHUB_SHA::8} \
             ${TAGS} .
+          echo ::set-output name=buildx_args_noroot::--platform ${DOCKER_PLATFORMS} \
+            --build-arg VERSION=${VERSION} \
+            --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+            --build-arg VCS_REF=${GITHUB_SHA::8} \
+            --build-arg RUNAS=noroot \
+            ${TAGS_NOROOT} .
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -64,6 +72,7 @@ jobs:
         name: Docker Buildx (build)
         run: |
           docker buildx build --no-cache --pull --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
+          docker buildx build --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args_noroot }}
       -
         name: Docker Login
         if: success() && github.event_name != 'pull_request'
@@ -77,11 +86,13 @@ jobs:
         if: success() && github.event_name != 'pull_request'
         run: |
           docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
+          docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args_noroot }}
       -
         name: Docker Check Manifest
         if: always() && github.event_name != 'pull_request'
         run: |
           docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+          docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}-noroot
       -
         name: Clear
         if: always() && github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ COPY --from=build /tmp/useradd/* /etc/
 COPY --from=build --chown=${RUNAS}  /go/bin/transfersh /go/bin/transfersh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-
 USER ${RUNAS}
 
 ENTRYPOINT ["/go/bin/transfersh", "--listener", ":8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,23 @@ ENV GO111MODULE=on
 # build & install server
 RUN CGO_ENABLED=0 go build -tags netgo -ldflags "-X github.com/dutchcoders/transfer.sh/cmd.Version=$(git describe --tags) -a -s -w -extldflags '-static'" -o /go/bin/transfersh
 
+ARG PUID=1000 \
+    PGID=1000
+
+RUN mkdir -p /tmp/useradd && \
+    echo "transfersh:x:${PUID}:${PGID}::/nonexistent:/sbin/nologin" >> /tmp/useradd/passwd && \
+    echo "transfersh:!:::::::" >> /tmp/useradd/shadow && \
+    echo "transfersh:x:${PGID}:" >> /tmp/useradd/group && \
+    echo "transfersh:!::" >> /tmp/useradd/groupshadow
+
 FROM scratch AS final
 LABEL maintainer="Andrea Spacca <andrea.spacca@gmail.com>"
 
-COPY --from=build  /go/bin/transfersh /go/bin/transfersh
+COPY --from=build /tmp/useradd/* /etc/
+COPY --from=build --chown=transfersh  /go/bin/transfersh /go/bin/transfersh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+USER transfersh
 
 ENTRYPOINT ["/go/bin/transfersh", "--listener", ":8080"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,23 +14,27 @@ ENV GO111MODULE=on
 # build & install server
 RUN CGO_ENABLED=0 go build -tags netgo -ldflags "-X github.com/dutchcoders/transfer.sh/cmd.Version=$(git describe --tags) -a -s -w -extldflags '-static'" -o /go/bin/transfersh
 
-ARG PUID=1000 \
-    PGID=1000
+ARG PUID=5000 \
+    PGID=5000 \
+    RUNAS
 
 RUN mkdir -p /tmp/useradd && \
-    echo "transfersh:x:${PUID}:${PGID}::/nonexistent:/sbin/nologin" >> /tmp/useradd/passwd && \
-    echo "transfersh:!:::::::" >> /tmp/useradd/shadow && \
-    echo "transfersh:x:${PGID}:" >> /tmp/useradd/group && \
-    echo "transfersh:!::" >> /tmp/useradd/groupshadow
+    if [ ! -z "$RUNAS" ]; then \
+    echo "${RUNAS}:x:${PUID}:${PGID}::/nonexistent:/sbin/nologin" >> /tmp/useradd/passwd && \
+    echo "${RUNAS}:!:::::::" >> /tmp/useradd/shadow && \
+    echo "${RUNAS}:x:${PGID}:" >> /tmp/useradd/group && \
+    echo "${RUNAS}:!::" >> /tmp/useradd/groupshadow; fi
 
 FROM scratch AS final
 LABEL maintainer="Andrea Spacca <andrea.spacca@gmail.com>"
+ARG RUNAS
 
 COPY --from=build /tmp/useradd/* /etc/
-COPY --from=build --chown=transfersh  /go/bin/transfersh /go/bin/transfersh
+COPY --from=build --chown=${RUNAS}  /go/bin/transfersh /go/bin/transfersh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-USER transfersh
+
+USER ${RUNAS}
 
 ENTRYPOINT ["/go/bin/transfersh", "--listener", ":8080"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p /tmp/useradd && \
     echo "${RUNAS}:x:${PUID}:${PGID}::/nonexistent:/sbin/nologin" >> /tmp/useradd/passwd && \
     echo "${RUNAS}:!:::::::" >> /tmp/useradd/shadow && \
     echo "${RUNAS}:x:${PGID}:" >> /tmp/useradd/group && \
-    echo "${RUNAS}:!::" >> /tmp/useradd/groupshadow; fi
+    echo "${RUNAS}:!::" >> /tmp/useradd/groupshadow; else touch /tmp/useradd/unused; fi
 
 FROM scratch AS final
 LABEL maintainer="Andrea Spacca <andrea.spacca@gmail.com>"

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ You can also build the container yourself. This allows you to choose which UID/G
 # * PUID:  UID of the process. Needs RUNAS != "". Defaults to 5000.
 # * PGID:  GID of the process. Needs RUNAS != "". Defaults to 5000.
 
-docker build -t tfsh-noroot --build-arg RUNAS=doesntmatter --build-arg PUID=1337 --build-arg PGID=1338 .
+docker build -t transfer.sh-noroot --build-arg RUNAS=doesntmatter --build-arg PUID=1337 --build-arg PGID=1338 .
 ```
 
 ## S3 Usage

--- a/README.md
+++ b/README.md
@@ -140,10 +140,29 @@ $ go build -o transfersh main.go
 
 ## Docker
 
-For easy deployment, we've created a Docker container.
+For easy deployment, we've created an official Docker container. There are two variants, differing only by which user runs the process.
+
+The default one will run as `root`:
 
 ```bash
 docker run --publish 8080:8080 dutchcoders/transfer.sh:latest --provider local --basedir /tmp/
+```
+
+The one tagged with the suffix `-noroot` will use `5000` as both UID and GID:
+```bash
+docker run --publish 8080:8080 dutchcoders/transfer.sh:latest-noroot --provider local --basedir /tmp/
+```
+
+### Building the Container
+You can also build the container yourself. This allows you to choose which UID/GID will be used, e.g. when using NFS mounts:
+```bash
+# Build arguments:
+# * RUNAS: If empty, the container will run as root.
+#          Set this to anything to enable UID/GID selection.
+# * PUID:  UID of the process. Needs RUNAS != "". Defaults to 5000.
+# * PGID:  GID of the process. Needs RUNAS != "". Defaults to 5000.
+
+docker build -t tfsh-noroot --build-arg RUNAS=doesntmatter --build-arg PUID=1337 --build-arg PGID=1338 .
 ```
 
 ## S3 Usage


### PR DESCRIPTION
I created a pull request to discuss my proposal in a dedicated thread and allow merging, if desired. I hope that's fine and I'm doing everything correctly, as I said, I'm mostly a lone lurker on here. Previous discussion is in https://github.com/dutchcoders/transfer.sh/pull/345, which is related. I made the newbie mistake and commited to main, so I had to clean up a little, which is why the previous links are a bit borked.

This PR introduces the option to create a Docker container running as an unprivileged user while retaining the previous default of running as root, and while still being based on `FROM scratch`. This avoids a breaking change for existing users and keeps the image as lean as it is. UID/GID can optionally be specified as well.

Setting the build argument `RUNAS` to anything will trigger the unprivileged mode. If it's unset, Docker will happily default to root in both `COPY --chown=${RUNAS}` and `USER ${RUNAS}`. To avoid an error when the glob `/tmp/useradd/*` returns nothing, I had to create a dummy file when building for root. The (relatively speaking) resource-heavy steps of compiling can be reused from cache when building different variants of the image.

* `docker build -t transfersh-root .` will result in an image which runs the container as root. The only change from before is the dummy file `/etc/unused`.
* `docker build -t transfersh-user --build-arg RUNAS=plsanythingbutroot .` will result in an image that runs the container with the default UID:GID of 5000:5000.
* `docker build -t transfersh-user-custom --build-arg RUNAS=verycustomsir --build-arg PUID=1337 --build-arg PGID=1338 .` will result in an image that runs the container with UID:GID of 1337:1338.

Apart from the good conscience of running as an unprivileged process, this also allows easy selection of an ID, e.g. when mapping NFS-mounted folders as the base dir. Furthermore, it would be possible to provide a separate official image like `transfersh:noroot` without much hassle. Current users wanting to switch manually would have to run a simple `sudo chown -R $UID:$GID ./data` on their host.

Fixes https://github.com/dutchcoders/transfer.sh/issues/100.