### PR TITLE
Fixed improper implementation of content type

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1038,7 +1038,7 @@ func (s *Server) getHandler(w http.ResponseWriter, r *http.Request) {
 		metadata.ContentType is unable to determine the type of the content, 
 		So add text/plain in this case to fix XSS related issues/
 		*/
-                if(contentType == ""){
+		if strings.TrimSpace(contentType) == "" {
 		      contentType := "text/plain"
 		 }
 	} else {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1039,7 +1039,7 @@ func (s *Server) getHandler(w http.ResponseWriter, r *http.Request) {
 		So add text/plain in this case to fix XSS related issues/
 		*/
 		if strings.TrimSpace(contentType) == "" {
-		      contentType := "text/plain"
+		      contentType = "text/plain"
 		 }
 	} else {
 		disposition = "attachment"

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1034,6 +1034,11 @@ func (s *Server) getHandler(w http.ResponseWriter, r *http.Request) {
 
 	if action == "inline" {
 		disposition = "inline"
+		/*
+		metadata.ContentType is unable to determine the type of the content, 
+		So add text/plain in this case to fix XSS related issues/
+		*/
+		contentType := "text/plain"
 	} else {
 		disposition = "attachment"
 	}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1038,7 +1038,9 @@ func (s *Server) getHandler(w http.ResponseWriter, r *http.Request) {
 		metadata.ContentType is unable to determine the type of the content, 
 		So add text/plain in this case to fix XSS related issues/
 		*/
-		contentType := "text/plain"
+                if(contentType == ""){
+		      contentType := "text/plain"
+		 }
 	} else {
 		disposition = "attachment"
 	}


### PR DESCRIPTION
Add text/plain content type if metadata.ContentType is unable to determine the content type of the file