### PR TITLE
Add /tmp dir to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG PUID=5000 \
     PGID=5000 \
     RUNAS
 
-RUN mkdir -p /tmp/useradd && \
+RUN mkdir -p /tmp/useradd /tmp/empty && \
     if [ ! -z "$RUNAS" ]; then \
     echo "${RUNAS}:x:${PUID}:${PGID}::/nonexistent:/sbin/nologin" >> /tmp/useradd/passwd && \
     echo "${RUNAS}:!:::::::" >> /tmp/useradd/shadow && \
@@ -29,6 +29,7 @@ FROM scratch AS final
 LABEL maintainer="Andrea Spacca <andrea.spacca@gmail.com>"
 ARG RUNAS
 
+COPY --from=build /tmp/empty /tmp
 COPY --from=build /tmp/useradd/* /etc/
 COPY --from=build --chown=${RUNAS}  /go/bin/transfersh /go/bin/transfersh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Hello, this small change fixes #462

Wondering if there is any reason not to include the `tmp` dir ?