### PR TITLE
Removed Warning for Nonexisting Malware

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ Easy and fast file sharing from the command-line. This code contains the server 
 
 Transfer.sh currently supports the s3 (Amazon S3), gdrive (Google Drive), storj (Storj) providers, and local file system (local).
 
-## Disclaimer
-
-The service at transfersh.com is of unknown origin and reported as cloud malware.
-
 ## Usage
 
 ### Upload:


### PR DESCRIPTION
The url seems seems to have been down since September according to Wayback Machine, or at least that's when it was last seen