### PR TITLE
Add `Vary` headers in responses

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -245,7 +245,7 @@ func canContainsXSS(contentType string) bool {
 
 /* The preview handler will show a preview of the content for browsers (accept type text/html), and referer is not transfer.sh */
 func (s *Server) previewHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Vary", "Accept, Referer, X-Decrypt-Password")
+	w.Header().Set("Vary", "Range, Referer, X-Decrypt-Password")
 
 	vars := mux.Vars(r)
 
@@ -1160,7 +1160,7 @@ func (s *Server) headHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "close")
 	w.Header().Set("X-Remaining-Downloads", remainingDownloads)
 	w.Header().Set("X-Remaining-Days", remainingDays)
-	w.Header().Set("Vary", "Accept, Referer, X-Decrypt-Password")
+	w.Header().Set("Vary", "Range, Referer, X-Decrypt-Password")
 
 	if s.storage.IsRangeSupported() {
 		w.Header().Set("Accept-Ranges", "bytes")
@@ -1254,7 +1254,7 @@ func (s *Server) getHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Length", strconv.FormatUint(contentLength, 10))
-	w.Header().Set("Vary", "Accept, Referer, X-Decrypt-Password")
+	w.Header().Set("Vary", "Range, Referer, X-Decrypt-Password")
 
 	if _, err = io.Copy(w, decryptionReader); err != nil {
 		s.logger.Printf("%s", err.Error())

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -245,7 +245,7 @@ func canContainsXSS(contentType string) bool {
 
 /* The preview handler will show a preview of the content for browsers (accept type text/html), and referer is not transfer.sh */
 func (s *Server) previewHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Vary", "Accept, X-Decrypt-Password")
+	w.Header().Set("Vary", "Accept, Referer, X-Decrypt-Password")
 
 	vars := mux.Vars(r)
 
@@ -1160,7 +1160,7 @@ func (s *Server) headHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "close")
 	w.Header().Set("X-Remaining-Downloads", remainingDownloads)
 	w.Header().Set("X-Remaining-Days", remainingDays)
-	w.Header().Set("Vary", "Accept, X-Decrypt-Password")
+	w.Header().Set("Vary", "Accept, Referer, X-Decrypt-Password")
 
 	if s.storage.IsRangeSupported() {
 		w.Header().Set("Accept-Ranges", "bytes")
@@ -1254,7 +1254,7 @@ func (s *Server) getHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Length", strconv.FormatUint(contentLength, 10))
-	w.Header().Set("Vary", "Accept, X-Decrypt-Password")
+	w.Header().Set("Vary", "Accept, Referer, X-Decrypt-Password")
 
 	if _, err = io.Copy(w, decryptionReader); err != nil {
 		s.logger.Printf("%s", err.Error())

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -245,6 +245,8 @@ func canContainsXSS(contentType string) bool {
 
 /* The preview handler will show a preview of the content for browsers (accept type text/html), and referer is not transfer.sh */
 func (s *Server) previewHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Vary", "Accept, X-Decrypt-Password")
+
 	vars := mux.Vars(r)
 
 	token := vars["token"]
@@ -397,6 +399,7 @@ func (s *Server) viewHandler(w http.ResponseWriter, r *http.Request) {
 		token(s.randomTokenLength),
 	}
 
+	w.Header().Set("Vary", "Accept")
 	if acceptsHTML(r.Header) {
 		if err := htmlTemplates.ExecuteTemplate(w, "index.html", data); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1157,6 +1160,7 @@ func (s *Server) headHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "close")
 	w.Header().Set("X-Remaining-Downloads", remainingDownloads)
 	w.Header().Set("X-Remaining-Days", remainingDays)
+	w.Header().Set("Vary", "Accept, X-Decrypt-Password")
 
 	if s.storage.IsRangeSupported() {
 		w.Header().Set("Accept-Ranges", "bytes")
@@ -1250,6 +1254,7 @@ func (s *Server) getHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Length", strconv.FormatUint(contentLength, 10))
+	w.Header().Set("Vary", "Accept, X-Decrypt-Password")
 
 	if _, err = io.Copy(w, decryptionReader); err != nil {
 		s.logger.Printf("%s", err.Error())


### PR DESCRIPTION
This prevents caching servers like Cloudflare from caching responses when `Accept` or `X-Decrypt-Password` request headers vary. Before this, servers like Cloudflare would cache the html preview page regardless of `Accept` header (meaning curls and non-browser requests would also return a cached preview page). Adding a `Vary` header should prevent that.

More info here: https://blog.cloudflare.com/vary-for-images-serve-the-correct-images-to-the-correct-browsers/