### PR TITLE
Add charset to content type in getHandler

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1218,7 +1218,7 @@ func (s *Server) getHandler(w http.ResponseWriter, r *http.Request) {
 			So add text/plain in this case to fix XSS related issues/
 		*/
 		if strings.TrimSpace(contentType) == "" {
-			contentType = "text/plain"
+			contentType = "text/plain; charset=utf-8"
 		}
 	} else {
 		disposition = "attachment"


### PR DESCRIPTION
When I use `https/transfer.sh/inline/....`, CJK letters are crashed, at least on MSEdge. It seems it's because of absence of charset (UTF-8).

So I added charset to content type in the getHandler function to fix CJK-letter related issues. If the content type is empty after trimming, set it to "text/plain; charset=utf-8".

BTW, I'm not familiar with REST APIs and this change is not tested yet, feel free to give me feedback. 