### PR TITLE
Add mime.types to docker container to select charset properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.17
 FROM golang:${GO_VERSION}-alpine as build
 
 # Necessary to run 'go get' and to compile the linked binary
-RUN apk add git musl-dev
+RUN apk add git musl-dev mailcap
 
 ADD . /go/src/github.com/dutchcoders/transfer.sh
 
@@ -29,6 +29,7 @@ FROM scratch AS final
 LABEL maintainer="Andrea Spacca <andrea.spacca@gmail.com>"
 ARG RUNAS
 
+COPY --from=build /etc/mime.types /etc/mime.types
 COPY --from=build /tmp/empty /tmp
 COPY --from=build /tmp/useradd/* /etc/
 COPY --from=build --chown=${RUNAS}  /go/bin/transfersh /go/bin/transfersh

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1218,7 +1218,7 @@ func (s *Server) getHandler(w http.ResponseWriter, r *http.Request) {
 			So add text/plain in this case to fix XSS related issues/
 		*/
 		if strings.TrimSpace(contentType) == "" {
-			contentType = "text/plain"
+			contentType = "text/plain; charset=utf-8"
 		}
 	} else {
 		disposition = "attachment"


### PR DESCRIPTION
This commit includes /etc/mime.types file to the container, which is necessary to properly select the charset using MIME typing during file upload.

For more information, read https://github.com/dutchcoders/transfer.sh/pull/545#issuecomment-1528712181

To test the PR, I built this image, ran this image on my server, and uploaded `greeting.txt`, which includes CJK letters.