### PR TITLE
Add URL encoding to transfer function to handle whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ You need to create an OAuth Client id from console.cloud.google.com, download th
 ### Bash and zsh (multiple files uploaded as zip archive)
 ##### Add this to .bashrc or .zshrc or its equivalent
 ```bash
-transfer(){ if [ $# -eq 0 ];then echo "No arguments specified.\nUsage:\n transfer <file|directory>\n ... | transfer <file_name>">&2;return 1;fi;if tty -s;then file="$1";file_name=$(basename "$file");if [ ! -e "$file" ];then echo "$file: No such file or directory">&2;return 1;fi;if [ -d "$file" ];then file_name="$file_name.zip" ,;(cd "$file"&&zip -r -q - .)|curl --progress-bar --upload-file "-" "https://transfer.sh/$file_name"|tee /dev/null,;else cat "$file"|curl --progress-bar --upload-file "-" "https://transfer.sh/$file_name"|tee /dev/null;fi;else file_name=$1;curl --progress-bar --upload-file "-" "https://transfer.sh/$file_name"|tee /dev/null;fi;}
+transfer(){ if [ $# -eq 0 ];then echo "No arguments specified.\nUsage:\n transfer <file|directory>\n ... | transfer <file_name>">&2;return 1;fi;if tty -s;then file="$1";file_name=$(basename "$file");if [ ! -e "$file" ];then echo "$file: No such file or directory">&2;return 1;fi;if [ -d "$file" ];then file_name="$file_name.zip" ,;(cd "$file"&&zip -r -q - .)|curl --progress-bar --upload-file "-" "https://transfer.sh/$(_urlencode $file_name)"|tee /dev/null;else cat "$file"|curl --progress-bar --upload-file "-" "https://transfer.sh/$(_urlencode $file_name)"|tee /dev/null;fi;else file_name=$1;curl --progress-bar --upload-file "-" "https://transfer.sh/$(_urlencode $file_name)"|tee /dev/null;fi;}; _urlencode () { python3 -c 'from sys import argv, stdin; from urllib.parse import quote; print(quote(argv[1] if argv[1:] else stdin.read()))' "$@" }
 ```
 
 #### Now you can use transfer function


### PR DESCRIPTION
Add URL encoding functionality to the `transfer` function in `README.md` so that file names with spaces can be uploaded correctly (e.g. `hello world.json`).

Also, the code uses the `_urlencode` function written in Python3. I know not every *nix OS includes Python3 by default but I'm familiar with Python and I don't know how to make it more portable.

This commit includes changes to the following:

- Update the `transfer` function to use `_urlencode` for encoding the file names as URL.
- Add the `_urlencode` function to URL encode the file names.

Since this oneliner is too hard to review, I uploaded formatted code too:
[before.txt](https://github.com/dutchcoders/transfer.sh/files/11359288/before.txt)
[after.txt](https://github.com/dutchcoders/transfer.sh/files/11359289/after.txt)

If this PR is okay, I'll make a PR to tranfer.sh-web too 
