### PR TITLE
Dockerfile: Use Go 1.20 by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Default to Go 1.17
-ARG GO_VERSION=1.17
+# Default to Go 1.20
+ARG GO_VERSION=1.20
 FROM golang:${GO_VERSION}-alpine as build
 
 # Necessary to run 'go get' and to compile the linked binary


### PR DESCRIPTION
Updating the default Go version used in the Dockerfile, to the latest one supported by the project at the moment.

Also, Go `1.17` support was removed in https://github.com/dutchcoders/transfer.sh/commit/9f1fe62e05115bd355799be7a633231686363c48