### PR TITLE
Improve purgeTime display in web page

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -374,7 +374,7 @@ func (s *Server) viewHandler(w http.ResponseWriter, r *http.Request) {
 
 	purgeTime := ""
 	if s.purgeDays > 0 {
-		purgeTime = s.purgeDays.String()
+		purgeTime = formatDurationDays(s.purgeDays)
 	}
 
 	data := struct {

--- a/server/utils.go
+++ b/server/utils.go
@@ -32,6 +32,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/golang/gddo/httputil/header"
 )
@@ -232,4 +233,12 @@ func formatSize(size int64) string {
 
 	getSuffix := suffixes[int(math.Floor(base))]
 	return fmt.Sprintf("%s %s", strconv.FormatFloat(newVal, 'f', -1, 64), getSuffix)
+}
+
+func formatDurationDays(durationDays time.Duration) string {
+	days := int(durationDays.Hours() / 24)
+	if days == 1 {
+		return fmt.Sprintf("%d day", days)
+	}
+	return fmt.Sprintf("%d days", days)
 }


### PR DESCRIPTION
- changing the line `purgeTime = s.purgeDays.String()` to use a function that formats the days like this: "N days" or "1 day"
- adding the function `formatDurationDays` in utils.go file

Fixes #557

![Screenshot from 2023-05-18 16-53-35](https://github.com/dutchcoders/transfer.sh/assets/30585029/c07d2bce-1d53-4fae-b688-26d6db372705)
![Screenshot from 2023-05-17 23-37-52](https://github.com/dutchcoders/transfer.sh/assets/30585029/1f4f7ae2-d327-4d02-8e5a-25e48c9e601a)
