### PR TITLE
Improve Docker layer caching for Go dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@ FROM golang:${GO_VERSION}-alpine as build
 # Necessary to run 'go get' and to compile the linked binary
 RUN apk add git musl-dev mailcap
 
-ADD . /go/src/github.com/dutchcoders/transfer.sh
-
 WORKDIR /go/src/github.com/dutchcoders/transfer.sh
 
-ENV GO111MODULE=on
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
 
 # build & install server
 RUN CGO_ENABLED=0 go build -tags netgo -ldflags "-X github.com/dutchcoders/transfer.sh/cmd.Version=$(git describe --tags) -a -s -w -extldflags '-static'" -o /go/bin/transfersh


### PR DESCRIPTION
Running `go mod download` before copying the entire project to the Docker image avoids dependencies from being re-downloaded every time any file is modified, and `docker build` runs again.

This follows the steps detailed in the official Docker guide for Go images:
https://docs.docker.com/language/golang/build-images/#create-a-dockerfile-for-the-application

Also, `GO111MODULE` doesn't make any difference for the supported Go versions, so it can be removed from the Dockerfile.