### PR TITLE
server/server.go: use TLS config provided by acme/autocert

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -274,9 +274,8 @@ func UseLetsEncrypt(hosts []string) OptionFn {
 			},
 		}
 
-		srvr.tlsConfig = &tls.Config{
-			GetCertificate: m.GetCertificate,
-		}
+		srvr.tlsConfig = m.TLSConfig()
+		srvr.tlsConfig.GetCertificate = m.GetCertificate
 	}
 }
 


### PR DESCRIPTION
Small suggestion based on go docs of acme autocert.