### PR TITLE
Normalize upload file name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/dutchcoders/go-virustotal v0.0.0-20140923143438-24cc8e6fa329
 	github.com/dutchcoders/transfer.sh-web v0.0.0-20221119114740-ca3a2621d2a6
 	github.com/elazarl/go-bindata-assetfs v1.0.1
+	github.com/emicklei/go-restful v2.16.0+incompatible
 	github.com/fatih/color v1.14.1
 	github.com/golang/gddo v0.0.0-20210115222349-20d68f94ee1f
 	github.com/gorilla/handlers v1.5.1
@@ -29,6 +30,7 @@ require (
 	golang.org/x/crypto v0.17.0
 	golang.org/x/net v0.17.0
 	golang.org/x/oauth2 v0.7.0
+	golang.org/x/text v0.14.0
 	google.golang.org/api v0.114.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	storj.io/common v0.0.0-20230301105927-7f966760c100
@@ -86,7 +88,6 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/grpc v1.56.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/dutchcoders/transfer.sh-web v0.0.0-20221119114740-ca3a2621d2a6 h1:7uT
 github.com/dutchcoders/transfer.sh-web v0.0.0-20221119114740-ca3a2621d2a6/go.mod h1:F6Q37CxDh2MHr5KXkcZmNB3tdkK7v+bgE+OpBY+9ilI=
 github.com/elazarl/go-bindata-assetfs v1.0.1 h1:m0kkaHRKEu7tUIUFVwhGGGYClXvyl4RE03qmvRTNfbw=
 github.com/elazarl/go-bindata-assetfs v1.0.1/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
+github.com/emicklei/go-restful v2.16.0+incompatible h1:rgqiKNjTnFQA6kkhFe16D8epTksy9HQ1MyrbDXSdYhM=
+github.com/emicklei/go-restful v2.16.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -46,7 +46,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -422,17 +421,22 @@ func (s *Server) notFoundHandler(w http.ResponseWriter, _ *http.Request) {
 	http.Error(w, http.StatusText(404), 404)
 }
 
-const newLineRegexp = "(\n|\r|\n\r)"
-
-var newLineRegexpCompiled = regexp.MustCompile(newLineRegexp)
-
 func sanitize(fileName string) string {
-	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	t := transform.Chain(
+		norm.NFD,
+		runes.Remove(runes.In(unicode.Cc)),
+		runes.Remove(runes.In(unicode.Cf)),
+		runes.Remove(runes.In(unicode.Co)),
+		runes.Remove(runes.In(unicode.Cs)),
+		runes.Remove(runes.In(unicode.Other)),
+		runes.Remove(runes.In(unicode.Zl)),
+		runes.Remove(runes.In(unicode.Zp)),
+		norm.NFC)
 	newName, _, err := transform.String(t, fileName)
 	if err != nil {
 		return path.Base(fileName)
 	}
-	newName = newLineRegexpCompiled.ReplaceAllLiteralString(newName, "_")
+	// newName = newLineRegexpCompiled.ReplaceAllLiteralString(newName, "_")
 	if len(newName) == 0 {
 		newName = "_"
 	}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -46,11 +46,13 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	textTemplate "text/template"
 	"time"
+	"unicode"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
@@ -66,6 +68,9 @@ import (
 	blackfriday "github.com/russross/blackfriday/v2"
 	qrcode "github.com/skip2/go-qrcode"
 	"golang.org/x/net/idna"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 )
 
 const getPathPart = "get"
@@ -417,8 +422,21 @@ func (s *Server) notFoundHandler(w http.ResponseWriter, _ *http.Request) {
 	http.Error(w, http.StatusText(404), 404)
 }
 
+const newLineRegexp = "(\n|\r|\n\r)"
+
+var newLineRegexpCompiled = regexp.MustCompile(newLineRegexp)
+
 func sanitize(fileName string) string {
-	return path.Base(fileName)
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	newName, _, err := transform.String(t, fileName)
+	if err != nil {
+		return path.Base(fileName)
+	}
+	newName = newLineRegexpCompiled.ReplaceAllLiteralString(newName, "_")
+	if len(newName) == 0 {
+		newName = "_"
+	}
+	return path.Base(newName)
 }
 
 func (s *Server) postHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -436,7 +436,6 @@ func sanitize(fileName string) string {
 	if err != nil {
 		return path.Base(fileName)
 	}
-	// newName = newLineRegexpCompiled.ReplaceAllLiteralString(newName, "_")
 	if len(newName) == 0 {
 		newName = "_"
 	}

--- a/server/token.go
+++ b/server/token.go
@@ -25,7 +25,9 @@ THE SOFTWARE.
 package server
 
 import (
-	"math/rand"
+	"crypto/rand"
+	"log"
+	"math/big"
 )
 
 const (
@@ -37,8 +39,11 @@ const (
 func token(length int) string {
 	result := ""
 	for i := 0; i < length; i++ {
-		x := rand.Intn(len(SYMBOLS) - 1)
-		result = string(SYMBOLS[x]) + result
+		x, err := rand.Int(rand.Reader, big.NewInt(int64(len(SYMBOLS))))
+		if err != nil {
+			log.Fatal("Failed to generate token")
+		}
+		result = string(SYMBOLS[x.Int64()]) + result
 	}
 
 	return result

--- a/server/token.go
+++ b/server/token.go
@@ -25,9 +25,7 @@ THE SOFTWARE.
 package server
 
 import (
-	"crypto/rand"
-	"log"
-	"math/big"
+	"math/rand"
 )
 
 const (
@@ -39,11 +37,8 @@ const (
 func token(length int) string {
 	result := ""
 	for i := 0; i < length; i++ {
-		x, err := rand.Int(rand.Reader, big.NewInt(int64(len(SYMBOLS))))
-		if err != nil {
-			log.Fatal("Failed to generate token")
-		}
-		result = string(SYMBOLS[x.Int64()]) + result
+		x := rand.Intn(len(SYMBOLS) - 1)
+		result = string(SYMBOLS[x]) + result
 	}
 
 	return result


### PR DESCRIPTION
We found a problem, that caused due too simple input normalize.
```
~/projects/transfer.sh main* ❯ echo test >'%21adasd'
~/projects/transfer.sh main* ❯ curl -v --upload-file "./%0A%0D" "http://localhost:8080/%0A%0D"                                                                                                                                                                                                                       
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080
> PUT /%0A%0D HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.4.0
> Accept: */*
> Content-Length: 5
>
* We are completely uploaded and fine
< HTTP/1.1 200 OK
< Content-Type: text/plain
< Server: Transfer.sh HTTP Server
< X-Made-With: <3 by DutchCoders
< X-Served-By: Proudly served by DutchCoders
< X-Url-Delete: http://localhost:8080/8lzy2BjFp3/%0A%0D/3HDeD5tY446rktKZ88fw
< Date: Wed, 06 Mar 2024 10:06:28 GMT
< Content-Length: 39
<
* Connection #0 to host localhost left intact
http://localhost:8080/8lzy2BjFp3/%0A%0D
```

```
~/projects/transfer.sh main* ❯ ls temp/8lzy2BjFp3                                                                                                                                                                                                                                                                   
??          ??.metadata
```

```
~/projects/transfer.sh main* ❯ curl 'http://localhost:8080/8lzy2BjFp3/%0A%0D' -v                                                                                                                                                                                                                                     
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080
> GET /8lzy2BjFp3/%0A%0D HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Cache-Control: no-store
< Connection: keep-alive
< Content-Disposition: attachment; filename="  "
< Content-Length: 5
< Content-Type:
< Server: Transfer.sh HTTP Server
< Vary: Range, Referer, X-Decrypt-Password
< X-Made-With: <3 by DutchCoders
< X-Remaining-Days: n/a
< X-Remaining-Downloads: n/a
< X-Served-By: Proudly served by DutchCoders
< Date: Wed, 06 Mar 2024 15:55:26 GMT
<
test
* Connection #0 to host localhost left intact
```

```
~/projects/transfer.sh main* ❯ curl 'http://localhost:8080/8lzy2BjFp3/%0A%0D'  -H 'Accept: text/html' -v                                                                                                                                                                                                             
*   Trying [::1]:8080...
* connect to ::1 port 8080 failed: Connection refused
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080
> GET /8lzy2BjFp3/%0A%0D HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.4.0
> Accept: text/html
>
< HTTP/1.1 500 Internal Server Error
< Content-Type: text/plain; charset=utf-8
< Server: Transfer.sh HTTP Server
< Vary: Range, Referer, X-Decrypt-Password
< X-Content-Type-Options: nosniff
< X-Made-With: <3 by DutchCoders
< X-Served-By: Proudly served by DutchCoders
< Date: Wed, 06 Mar 2024 15:55:18 GMT
< Content-Length: 65
<
runtime error: invalid memory address or nil pointer dereference
* Connection #0 to host localhost left intact
```

If we look into https://github.com/dutchcoders/transfer.sh/blob/main/server/handlers.go#L253 filename variable when we use GET method with HEADERS, we will see "\n\r" in variable, and it's lead to runtime error.
I realized filename normalization and trimming all newlines in user input in sanitize function 