### PR TITLE
LISTENER env not working, needs `--listener`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ https://transfer.sh/1lDau/test.txt --> https://transfer.sh/inline/1lDau/test.txt
 
 Parameter | Description                                                                                 | Value                        | Env                         
 --- |---------------------------------------------------------------------------------------------|------------------------------|-----------------------------
-listener | port to use for http (:80)                                                                  |                              | LISTENER                    |
+listener | port to use for http (:80)                                                                  |                              | Unsupported, use command args `--listener :8082`|
 profile-listener | port to use for profiler (:6060)                                                            |                              | PROFILE_LISTENER            |
 force-https | redirect to https                                                                           | false                        | FORCE_HTTPS                 
 tls-listener | port to use for https (:443)                                                                |                              | TLS_LISTENER                |


### PR DESCRIPTION
I tried overriding the port using envvar `LISTENER` but it didn't work, I tried:

```env
LISTENER=8082
LISTENER=:8082
```

It does work via args:

```yml
command: ["--provider", "local", "--listener", ":8082"]
```