### PR TITLE
update aws credentitas build

### DIFF
--- a/server/storage/s3.go
+++ b/server/storage/s3.go
@@ -179,7 +179,7 @@ func (s *S3Storage) Put(ctx context.Context, token string, filename string, read
 func (s *S3Storage) IsRangeSupported() bool { return true }
 
 func getAwsConfig(ctx context.Context, accessKey, secretKey string) (aws.Config, error) {
-	if accessKey == "" || accessKey == "" {
+	if accessKey == "" || secretKey == "" {
 		return config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	}
 	return config.LoadDefaultConfig(ctx,

--- a/server/storage/s3.go
+++ b/server/storage/s3.go
@@ -179,6 +179,9 @@ func (s *S3Storage) Put(ctx context.Context, token string, filename string, read
 func (s *S3Storage) IsRangeSupported() bool { return true }
 
 func getAwsConfig(ctx context.Context, accessKey, secretKey string) (aws.Config, error) {
+	if accessKey == "" || accessKey == "" {
+		return config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	}
 	return config.LoadDefaultConfig(ctx,
 		config.WithCredentialsProvider(credentials.StaticCredentialsProvider{
 			Value: aws.Credentials{


### PR DESCRIPTION
This PR enhances the AWS configuration logic by introducing support for the AWS default credential provider chain.
When accessKey and secretKey are empty, allowing it to automatically load credentials from multiple AWS-supported sources such as:

**Environment variables**

- Shared credentials/config files (~/.aws/credentials, ~/.aws/config)

- EC2/ECS instance roles

- EKS Pod Identity

This change improves flexibility and simplifies configuration in environments where credentials are already managed by AWS.

**Changes**

Updated getAwsConfig to use the AWS default credential chain when accessKey or secretKey is not provided.
Retains existing behavior (manual static credentials) when both keys are explicitly specified.