### PR TITLE
update aws credentials build

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,11 @@ For the usage with a AWS S3 Bucket, you just need to specify the following optio
 
 If you specify the s3-region, you don't need to set the endpoint URL since the correct endpoint will used automatically.
 
+If you don't explicitly specify the aws-access-key and aws-secret-key, the AWS default credential provider chain is used. so support:
+- Shared credentials/config files (~/.aws/credentials, ~/.aws/config)
+- EC2/ECS instance roles
+- EKS Pod Identity
+
 <br />
 
 ### Custom S3 providers

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -484,11 +484,9 @@ func New() *Cmd {
 
 		switch provider := c.String("provider"); provider {
 		case "s3":
-			if accessKey := c.String("aws-access-key"); accessKey == "" {
-				return errors.New("access-key not set.")
-			} else if secretKey := c.String("aws-secret-key"); secretKey == "" {
-				return errors.New("secret-key not set.")
-			} else if bucket := c.String("bucket"); bucket == "" {
+			accessKey := c.String("aws-access-key")
+			secretKey := c.String("aws-secret-key")
+			if bucket := c.String("bucket"); bucket == "" {
 				return errors.New("bucket not set.")
 			} else if store, err := storage.NewS3Storage(c.Context, accessKey, secretKey, bucket, purgeDays, c.String("s3-region"), c.String("s3-endpoint"), c.Bool("s3-no-multipart"), c.Bool("s3-path-style"), logger); err != nil {
 				return err

--- a/server/storage/s3.go
+++ b/server/storage/s3.go
@@ -179,7 +179,7 @@ func (s *S3Storage) Put(ctx context.Context, token string, filename string, read
 func (s *S3Storage) IsRangeSupported() bool { return true }
 
 func getAwsConfig(ctx context.Context, accessKey, secretKey string) (aws.Config, error) {
-	if accessKey == "" || accessKey == "" {
+	if accessKey == "" || secretKey == "" {
 		return config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	}
 	return config.LoadDefaultConfig(ctx,

--- a/server/storage/s3.go
+++ b/server/storage/s3.go
@@ -180,7 +180,7 @@ func (s *S3Storage) IsRangeSupported() bool { return true }
 
 func getAwsConfig(ctx context.Context, accessKey, secretKey string) (aws.Config, error) {
 	if accessKey == "" || secretKey == "" {
-		return config.LoadDefaultConfig(ctx, config.WithRegion(region))
+		return config.LoadDefaultConfig(ctx)
 	}
 	return config.LoadDefaultConfig(ctx,
 		config.WithCredentialsProvider(credentials.StaticCredentialsProvider{

--- a/server/storage/s3.go
+++ b/server/storage/s3.go
@@ -179,6 +179,9 @@ func (s *S3Storage) Put(ctx context.Context, token string, filename string, read
 func (s *S3Storage) IsRangeSupported() bool { return true }
 
 func getAwsConfig(ctx context.Context, accessKey, secretKey string) (aws.Config, error) {
+	if accessKey == "" || accessKey == "" {
+		return config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	}
 	return config.LoadDefaultConfig(ctx,
 		config.WithCredentialsProvider(credentials.StaticCredentialsProvider{
 			Value: aws.Credentials{


### PR DESCRIPTION
This PR enhances the AWS configuration logic by introducing support for the AWS default credential provider chain.
When accessKey and secretKey are empty, allowing it to automatically load credentials from multiple AWS-supported sources such as:

**Environment variables**

- Shared credentials/config files (~/.aws/credentials, ~/.aws/config)
- EC2/ECS instance roles
- EKS Pod Identity

This change improves flexibility and simplifies configuration in environments where credentials are already managed by AWS.

**Changes**

Updated getAwsConfig to use the AWS default credential chain when accessKey or secretKey is not provided.
Retains existing behavior (manual static credentials) when both keys are explicitly specified.