### PR TITLE
Trim prefixed '/' from proxy path

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ nightly| Scheduled CI build every midnight UTC
 nightly-noroot| Scheduled CI build every midnight UTC using [no root]
 edge| Latest CI build after every commit on `main`
 edge-noroot| Latest CI build after every commit on `main` using [no root]
-x.y.z| CI build after tagging a release
-x.y.z-noroot| CI build after tagging a release using [no root]
+v`x.y.z`| CI build after tagging a release
+v`x.y.z`-noroot| CI build after tagging a release using [no root]
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ ip-whitelist | comma separated list of ips allowed to connect to the service    
 ip-blacklist | comma separated list of ips not allowed to connect to the service                    |                               | IP_BLACKLIST                  |
 temp-path | path to temp folder                                                                     | system temp                   | TEMP_PATH                     |
 web-path | path to static web files (for development or custom front end)                           |                               | WEB_PATH                      |
-proxy-path | path prefix when service is run behind a proxy                                         |                               | PROXY_PATH                    |
+proxy-path | path prefix when service is run behind a proxy (a `/` prefix will be trimmed)          |                               | PROXY_PATH                    |
 proxy-port | port of the proxy when the service is run behind a proxy                               |                               | PROXY_PORT                    |
 email-contact | email contact for the front end                                                     |                               | EMAIL_CONTACT                 |
 ga-key | google analytics key for the front end                                                     |                               | GA_KEY                        |

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -771,7 +771,7 @@ func resolveWebAddress(r *http.Request, proxyPath string, proxyPort string) stri
 		webAddress = fmt.Sprintf("%s://%s/%s",
 			rUrl.ResolveReference(rUrl).Scheme,
 			rUrl.ResolveReference(rUrl).Host,
-			proxyPath)
+			strings.TrimPrefix(proxyPath, "/"))
 	}
 
 	return webAddress


### PR DESCRIPTION
This is a minor change.

| before | after |
| --- | --- |
|  <img width="735" height="217" alt="before" src="https://github.com/user-attachments/assets/274de420-e6b6-429d-b742-c50d04a38d38" /> | <img width="735" height="209" alt="after" src="https://github.com/user-attachments/assets/6d29dcdd-c7cc-4687-9ad4-856f423daf61" /> |

Alternative solution would be to mention in the documentation that the proxy path should not be prefixed with a `/`.

Also updated README to fix the missing `v` in the docker image tag. 

FYI: Thanks for transfer.sh 👍🏾 