### PR TITLE
Fix missing newline in PUT handler response

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -739,7 +739,7 @@ func (s *Server) putHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("X-Url-Delete", resolveURL(r, deleteURL, s.proxyPort))
 
-	_, _ = w.Write([]byte(resolveURL(r, relativeURL, s.proxyPort)))
+	_, _ = w.Write([]byte(resolveURL(r, relativeURL, s.proxyPort) + "\n"))
 }
 
 func resolveURL(r *http.Request, u *url.URL, proxyPort string) string {


### PR DESCRIPTION
## Summary
- Add trailing newline to the URL response in `putHandler` to match the behavior of `postHandler`

## Problem
When using `curl --upload-file` to upload files, the returned URL was not followed by a newline, causing the terminal prompt to appear on the same line as the URL:

```
https://transfer.sh/xxx/file.txtuser@host:~$
```

## Solution
Added `"\n"` to the response body in `putHandler` (line 742 in `server/handlers.go`), matching the behavior of `postHandler` which uses `fmt.Sprintln`.

## After Fix
```
https://transfer.sh/xxx/file.txt
user@host:~$
```

## Test plan
- [x] Tested with `curl --upload-file` command
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)